### PR TITLE
Feat/sign set frame message

### DIFF
--- a/TSISP003-Net/SignControllerDataStore/Entities/SignSetMessage.cs
+++ b/TSISP003-Net/SignControllerDataStore/Entities/SignSetMessage.cs
@@ -1,0 +1,20 @@
+namespace TSISP003_Net.SignControllerDataStore.Entities;
+
+public class SignSetMessage
+{
+    public byte MessageID { get; set; }
+    public byte Revision { get; set; }
+    public byte TransitionTimeBetweenFrames { get; set; }
+    public byte Frame1ID { get; set; }
+    public byte Frame1Time { get; set; }
+    public byte Frame2ID { get; set; }
+    public byte Frame2Time { get; set; }
+    public byte Frame3ID { get; set; }
+    public byte Frame3Time { get; set; }
+    public byte Frame4ID { get; set; }
+    public byte Frame4Time { get; set; }
+    public byte Frame5ID { get; set; }
+    public byte Frame5Time { get; set; }
+    public byte Frame6ID { get; set; }
+    public byte Frame6Time { get; set; }
+}

--- a/TSISP003-Net/SignControllerService/ISignControllerService.cs
+++ b/TSISP003-Net/SignControllerService/ISignControllerService.cs
@@ -13,7 +13,7 @@ public interface ISignControllerService : IHostedService
     Task EndSession();
     Task SystemReset(byte groupId, byte resetLevel);
     Task UpdateTime();
-    Task SignSetTextFrame();
+    Task<SignStatusReply> SignSetTextFrame(SignSetTextFrame request);
     Task SignSetGraphicsFrame();
     Task SignSetHighResolutionGraphicsFrame();
     Task SignConfigurationRequest();

--- a/TSISP003-Net/Utils/Extensions.cs
+++ b/TSISP003-Net/Utils/Extensions.cs
@@ -213,7 +213,7 @@ public static class Extensions
             Colour = signSetTextFrameDto.Colour,
             Conspicuity = signSetTextFrameDto.Conspicuity,
             Text = hexText,
-            NumberOfCharsInText = (byte)hexText.Length,
+            NumberOfCharsInText = (byte)(hexText.Length / 2),
             CRC = Functions.PacketCRCushort(Encoding.ASCII.GetBytes(hexText))
         };
     }


### PR DESCRIPTION
This pull request includes significant changes to the `SignSetTextFrame` functionality in the `TSISP003-Net` project. The changes involve updating method signatures, implementing new logic for handling requests, and adding a new entity class.

### Changes to `SignSetTextFrame` functionality:

* [`TSISP003-Net/Controllers/SignApiController.cs`](diffhunk://#diff-5b49196624019a935d47ceb3874e8d0d6b0261059afe3131489eba2d61d1bbafL26-R52): Updated the `SignSetTextFrame` method to accept a `SignSetTextFrameDto` request body and implemented the logic for handling the request, including error handling for timeouts and rejected requests.

* [`TSISP003-Net/SignControllerService/ISignControllerService.cs`](diffhunk://#diff-86e6e52a2e2dbabe6930fe9e3ccc787e9708948f7ddde5b77ea73147baca97ddL16-R16): Modified the `SignSetTextFrame` method signature to accept a `SignSetTextFrame` request and return a `SignStatusReply`.

* [`TSISP003-Net/SignControllerService/SignControllerService.cs`](diffhunk://#diff-31f022895fa273c6aa5e13d8da54934415273cfbf2c0b28d3ccc2aea4b7b20d0L476-R518): Implemented the `SignSetTextFrame` method to build the message, send it via TCP, and handle the response or timeout. Also updated the `ProcessSignSetTextFrame` method to correctly parse the application data. [[1]](diffhunk://#diff-31f022895fa273c6aa5e13d8da54934415273cfbf2c0b28d3ccc2aea4b7b20d0L476-R518) [[2]](diffhunk://#diff-31f022895fa273c6aa5e13d8da54934415273cfbf2c0b28d3ccc2aea4b7b20d0L494-R534)

### New entity class:

* [`TSISP003-Net/SignControllerDataStore/Entities/SignSetMessage.cs`](diffhunk://#diff-bb686e3f2ecb2507f73d7ced710072f412d09d1a2256b22e8810b6ee588065f7R1-R20): Added a new `SignSetMessage` class to represent the sign set message entity with properties for message ID, revision, transition times, and frame IDs.

### Utility method update:

* [`TSISP003-Net/Utils/Extensions.cs`](diffhunk://#diff-bb59e1d2c241f9f77f24a41c98b225ca1bc6451c51ad7012725de253ddc93e25L216-R216): Fixed the `AsEntity` extension method for `SignSetTextFrameDto` to correctly calculate the `NumberOfCharsInText` by dividing the length of the hex text by 2.