### PR TITLE
TSI-SP-003 simulator, multi-controller support, and extended management endpoints

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,6 +1,9 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <!-- Allow the PackageVersion entries below to pin transitive dependencies
+         (used to bump vulnerable transitive packages to patched versions). -->
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,6 +13,8 @@
 
     <!-- Aspire -->
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.1.2" />
+    <!-- Pinned to a patched version to clear NU1903 (CVE-2026-48109); pulled in transitively by Aspire. -->
+    <PackageVersion Include="MessagePack" Version="2.5.301" />
 
     <!-- Service Defaults / Observability -->
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
@@ -18,8 +23,10 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.4.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.4.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
+    <!-- 1.15.3 clears NU1902: OTLP-exporter advisory fixed in 1.15.2, Api advisory in 1.15.3. -->
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.1.2" />
 
     <!-- Service Defaults / Observability -->
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.4.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.4.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,6 +12,7 @@
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.1.2" />
 
     <!-- Service Defaults / Observability -->
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.4.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.4.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,6 +12,7 @@
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.1.2" />
 
     <!-- Service Defaults / Observability -->
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.4.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.4.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,6 +12,8 @@
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.1.2" />
 
     <!-- Service Defaults / Observability -->
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.4.0" />

--- a/Docs/superpowers/plans/2026-06-18-tsisp003-simulator.md
+++ b/Docs/superpowers/plans/2026-06-18-tsisp003-simulator.md
@@ -1,0 +1,1581 @@
+# TSISP003 Simulator Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a TCP server that impersonates a TSI-SP-003 roadside sign controller (the "slave"), accepting the protocol's "set" commands, storing frames/messages/plans in in-memory storage, tracking display state, and answering status / request-stored queries so the existing `TSISP003.Api` client can round-trip end-to-end with no hardware.
+
+**Architecture:** Extract the existing `ProtocolHelper`/`ProtocolConstants` into a new shared `TSISP003.Protocol` library so the client and simulator frame/CRC/password with identical code. Add a `TSISP003.Simulator` console host running a `BackgroundService` TCP listener. Each connection gets a `SimulatorSession` (state machine: `Idle → SeedSent → Online`) that decodes packets with a new `PacketCodec`, routes MI codes to handlers, mutates a `SimulatorMemory`, and emits byte-compatible replies built by `SimulatorReplyBuilder`.
+
+**Tech Stack:** .NET 10, C#, `System.Net.Sockets.TcpListener`, `Microsoft.Extensions.Hosting` (Generic Host / `BackgroundService`), xUnit + Moq for tests.
+
+## Global Constraints
+
+- Target framework: `net10.0` (inherited from `Directory.Build.props`; do not add a `TargetFramework` to new csproj files unless the repo pattern requires it — match sibling projects).
+- Clean Architecture dependency rule: `TSISP003.Protocol` has **no** project dependencies. `TSISP003.Infrastructure` references `TSISP003.Protocol`. `TSISP003.Simulator` references `TSISP003.Protocol` only (it must NOT reference Infrastructure/Application/Domain).
+- All protocol numeric fields are ASCII-hex (2 hex chars per byte) EXCEPT the two decimal-encoded fields in Sign Status Reply called out in Task 5.
+- Packet CRC is CRC-CCITT (poly `0x1021`, init `0x0000`) over the **ASCII bytes of the packet string** from `SOH` through end of application data, rendered as 4 uppercase hex chars (`ProtocolHelper.PacketCRC`).
+- Sequence numbers: start at 0 at link establishment, then cycle 1..255 (`0→1→…→255→1`). Use the same `IncrementSequenceNumber` rule as the client.
+- Use centralized package versions (repo uses Central Package Management — `Directory.Packages.props`). Add `<PackageReference Include="..." />` WITHOUT a `Version=` attribute; add the version to `Directory.Packages.props` if not already present.
+- Tests live in `tests/TSISP003.Tests` (existing xUnit project). Run a single test with `dotnet test tests/TSISP003.Tests/TSISP003.Tests.csproj --filter "FullyQualifiedName~<Name>"`.
+- Commit after each task with a `feat:`/`refactor:`/`test:` prefixed message.
+
+---
+
+## Reference: exact wire formats the simulator must speak
+
+These are derived from the real client in `src/TSISP003.Infrastructure/Services/SignControllerService.cs`. The simulator must EMIT what the client PARSES and PARSE what the client EMITS.
+
+**Data packet (both directions):**
+```
+SOH | N(S):2hex | N(R):2hex | ADDR:2hex | STX | MI:2hex | appdata… | CRC:4hex | ETX
+```
+- `SOH=0x01 STX=0x02 ETX=0x03 ACK=0x06 NAK=0x15`
+- CRC = `ProtocolHelper.PacketCRC(Encoding.ASCII.GetBytes(stringFromSohThroughAppdata))`.
+
+**Link ACK / NAK packet (slave→master, no STX):**
+```
+ACK | N(R):2hex | ADDR:2hex | CRC:4hex | ETX        (NAK identical with 0x15)
+```
+Client reads `packet[1..3]` as the slave's N(R), `packet[3..5]` as ADDR. (Client does NOT verify CRC on inbound packets, but we compute it correctly anyway.)
+
+**Handshake (slave replies):**
+- On `Start Session` (MI 02): send link-ACK, then data packet `MI=03` + seed (1 byte / 2 hex). Client reads seed from `packet[10..12]`.
+- On `Password` (MI 04): validate via `ProtocolHelper.GeneratePassword(seed, seedOffset, passwordOffset)` (compare last 4 hex of result to the 4-hex payload). Send link-ACK, then data packet `MI=01` (Acknowledge, no payload).
+
+**Heartbeat (MI 05):** reply with Sign Status Reply data packet `MI=06`.
+
+**Sign Status Reply (MI 06) application-data layout (hex offsets into appdata string, MI at [0..2]):**
+| offset | field | encoding |
+|--------|-------|----------|
+| 0..2   | MI = `06` | hex |
+| 2..4   | Online status (`01`=online) | hex |
+| 4..6   | Application error code | hex |
+| 6..8   | Day | hex |
+| 8..10  | Month | hex |
+| 10..14 | Year (e.g. 2025 → `07E9`) | **4-hex big-endian word** (`year.ToString("X4")`) |
+| 14..16 | Hour | hex |
+| 16..18 | Minute | hex |
+| 18..20 | Second | hex |
+| 20..24 | Controller checksum (WORD) | hex (any value; client ignores) |
+| 24..26 | Controller error code | **2-digit DECIMAL** (`value.ToString("D2")`) |
+| 26..28 | Number of signs | **2-digit DECIMAL** (`count.ToString("D2")`) |
+| then per sign, 18 hex (9 bytes) | SignID, SignErrorCode, SignEnabled(`01`), FrameID, FrameRevision, MessageID, MessageRevision, PlanID, PlanRevision | hex |
+
+**Sign Configuration Reply (MI 22) application-data layout:**
+`22` + manufacturer code (10 bytes = 20 hex, any value) + numberOfGroups(1 byte hex) + per group: GroupID(1), NumSigns(1), per sign: SignID(1), Type(1), Width(WORD low-byte-first = `lo hi`), Height(WORD low-byte-first), then SignatureLength(1) + signature bytes. All hex.
+
+**Report Enabled Plans (MI 13):** `13` + numEntries(1 byte hex) + per entry: GroupID(1) PlanID(1).
+
+**Set Text Frame (MI 0A) — master→slave appdata the simulator must PARSE:**
+`0A` + FrameID(1) + Revision(1) + Font(1) + Colour(1) + Conspicuity(1) + NumChars(1) + Text(NumChars bytes hex) + **embedded app-CRC (4 hex)**. The embedded CRC is `PacketCRC(GetBytes(HexToAscii(appMsgWithoutEmbeddedCrc)))`. The packet CRC follows as usual.
+
+**Set Graphics Frame (MI 0B):** `0B` + FrameID + Revision + Rows + Cols + Colour + Conspicuity + GraphicsLength(WORD, 4 hex) + GraphicsData(Length bytes) + embedded app-CRC(4 hex).
+
+**Set Hi-Res Graphics Frame (MI 1D):** `1D` + FrameID + Revision + Rows(WORD 4hex) + Cols(WORD 4hex) + Colour + Conspicuity + GraphicsLength(DWORD 8hex) + GraphicsData + embedded app-CRC(4 hex).
+
+**Set Message (MI 0C):** `0C` + MessageID + Revision + TransitionTime + (Frame1ID,Frame1Time)…(Frame6ID,Frame6Time). No embedded app-CRC.
+
+**Set Plan (MI 0D):** `0D` + PlanID + Revision + DayOfWeek + up to 6×(Type,ID,StartHour,StartMin,StopHour,StopMin); a trailing `00` terminator when fewer than 6 entries.
+
+**Display Frame (MI 0E):** `0E` + GroupID + FrameID → reply `*ACK` (MI 01). **Display Message (MI 0F):** `0F` + GroupID + MessageID → `*ACK`. **Display Atomic Frames (MI 2B):** `2B` + GroupID + NumSigns + (SignID,FrameID)… → Sign Status Reply (MI 06).
+
+**Enable Plan (MI 10):** `10` + GroupID + PlanID → `*ACK`. **Disable Plan (MI 11):** `11` + GroupID + PlanID → `*ACK`. **Request Enabled Plans (MI 12):** `12` → Report Enabled Plans (MI 13).
+
+**Sign Request Stored (MI 17):** `17` + RequestType(1) + RequestID(1). RequestType: 1=Frame, 2=Message, 3=Plan (see `Domain/Enums/RequestType.cs` — confirm values when implementing). Reply by re-emitting the stored item's set-command packet (MI 0A/0B/1D/0C/0D). Reject (MI 00) if not found.
+
+**Reject (MI 00):** `00` + rejectedMI(1) + applicationErrorCode(1). Used for unsupported MIs (HAR 0x40-0x48, weather 0x80-0x87) and not-found/ malformed requests.
+
+---
+
+## Task 1: Extract shared `TSISP003.Protocol` library
+
+**Files:**
+- Create: `src/TSISP003.Protocol/TSISP003.Protocol.csproj`
+- Create: `src/TSISP003.Protocol/ProtocolConstants.cs` (moved)
+- Create: `src/TSISP003.Protocol/ProtocolHelper.cs` (moved)
+- Delete: `src/TSISP003.Infrastructure/Protocol/ProtocolConstants.cs`
+- Delete: `src/TSISP003.Infrastructure/Protocol/ProtocolHelper.cs`
+- Modify: `src/TSISP003.Infrastructure/TSISP003.Infrastructure.csproj` (add ProjectReference)
+- Modify: `TSISP003-Net.slnx` (register new project)
+- Modify: every file with `using TSISP003.Infrastructure.Protocol;` (replace with `using TSISP003.Protocol;`)
+
+**Interfaces:**
+- Produces: namespace `TSISP003.Protocol` exposing `ProtocolConstants` (all `MI_*`, `SOH/STX/ETX/EOT/ACK/NAK`) and `ProtocolHelper` (`PacketCRC`, `PacketCRCushort`, `CRCGenerator`, `GetChunks`, `GeneratePassword`, `HexToAscii`, `AsciiToHex`, `PrintMessagePacket`) — identical signatures to today.
+
+- [ ] **Step 1: Find all references to the old namespace**
+
+Run: `grep -rl "TSISP003.Infrastructure.Protocol" src tests`
+Expected: a list including `SignControllerService.cs` and possibly test files. Record it.
+
+- [ ] **Step 2: Create the new project file**
+
+Create `src/TSISP003.Protocol/TSISP003.Protocol.csproj`. Match a sibling leaf library (`src/TSISP003.Domain/TSISP003.Domain.csproj`) exactly in structure:
+
+```bash
+cat src/TSISP003.Domain/TSISP003.Domain.csproj
+```
+Mirror it (same `<Project Sdk=...>` and `<PropertyGroup>` content), changing only any assembly/name specifics if present. Most likely the whole file is just:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>
+```
+
+- [ ] **Step 3: Move the two files and change their namespace**
+
+```bash
+git mv src/TSISP003.Infrastructure/Protocol/ProtocolConstants.cs src/TSISP003.Protocol/ProtocolConstants.cs
+git mv src/TSISP003.Infrastructure/Protocol/ProtocolHelper.cs src/TSISP003.Protocol/ProtocolHelper.cs
+```
+Then edit both moved files: change `namespace TSISP003.Infrastructure.Protocol;` → `namespace TSISP003.Protocol;`. `ProtocolHelper.cs` keeps `using System.Text;` and `using Microsoft.Extensions.Logging;` (it depends on `ILogger`). Add `<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />` to the new csproj (version via CPM — see Step 4).
+
+- [ ] **Step 4: Wire dependencies**
+
+Add the logging-abstractions package. Check `Directory.Packages.props` for an existing `Microsoft.Extensions.Logging.Abstractions` entry; if absent, add `<PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="<same major as other MS.Extensions packages>" />`. Add `<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />` to `TSISP003.Protocol.csproj`.
+
+In `src/TSISP003.Infrastructure/TSISP003.Infrastructure.csproj`, add under the `<ItemGroup>` that holds ProjectReferences:
+```xml
+<ProjectReference Include="..\TSISP003.Protocol\TSISP003.Protocol.csproj" />
+```
+
+In `TSISP003-Net.slnx`, add inside the `/src/` folder block:
+```xml
+<Project Path="src/TSISP003.Protocol/TSISP003.Protocol.csproj" />
+```
+
+- [ ] **Step 5: Update all `using` statements**
+
+For each file found in Step 1, replace `using TSISP003.Infrastructure.Protocol;` with `using TSISP003.Protocol;`.
+
+Run: `grep -rl "TSISP003.Infrastructure.Protocol" src tests`
+Expected: no output (empty).
+
+- [ ] **Step 6: Build and run existing tests to verify the refactor is behavior-preserving**
+
+Run: `dotnet build TSISP003-Net.slnx`
+Expected: Build succeeded, 0 errors.
+
+Run: `dotnet test TSISP003-Net.slnx`
+Expected: all existing tests pass (same count as before the change).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "refactor: extract shared TSISP003.Protocol library"
+```
+
+---
+
+## Task 2: `PacketCodec` — build & parse frames
+
+**Files:**
+- Create: `src/TSISP003.Protocol/PacketCodec.cs`
+- Test: `tests/TSISP003.Tests/Protocol/PacketCodecTests.cs`
+
+**Interfaces:**
+- Consumes: `ProtocolConstants`, `ProtocolHelper` from `TSISP003.Protocol`.
+- Produces:
+  - `record DataPacket(int Ns, int Nr, string Addr, int Mi, string AppData)` where `AppData` is the full hex application string INCLUDING the 2-hex MI prefix (matches the client's `applicationData` convention, e.g. `DispatchDataPacket` passes `packet[8..^5]`).
+  - `static class PacketCodec` with:
+    - `string BuildData(int ns, int nr, string addr, string appDataWithMi)` → full `SOH…ETX` string with packet CRC.
+    - `string BuildAck(int nr, string addr)` and `string BuildNak(int nr, string addr)` → link packets.
+    - `bool TryParse(string packet, out DataPacket data, out char kind)` where `kind` is `'D'` (data/SOH), `'A'` (ACK), `'N'` (NAK); returns false on malformed.
+    - `bool VerifyCrc(string packet)` → recomputes packet CRC over `SOH..end-of-appdata` and compares the 4 hex before `ETX`.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/TSISP003.Tests/Protocol/PacketCodecTests.cs`:
+
+```csharp
+using TSISP003.Protocol;
+using Xunit;
+
+namespace TSISP003.Tests.Protocol;
+
+public class PacketCodecTests
+{
+    [Fact]
+    public void BuildData_ThenTryParse_RoundTrips()
+    {
+        // appdata = MI 06 + one byte payload "AB"
+        string packet = PacketCodec.BuildData(ns: 1, nr: 2, addr: "01", appDataWithMi: "06AB");
+
+        Assert.Equal(ProtocolConstants.SOH, packet[0]);
+        Assert.Equal(ProtocolConstants.ETX, packet[^1]);
+
+        Assert.True(PacketCodec.TryParse(packet, out var data, out char kind));
+        Assert.Equal('D', kind);
+        Assert.Equal(1, data.Ns);
+        Assert.Equal(2, data.Nr);
+        Assert.Equal("01", data.Addr);
+        Assert.Equal(0x06, data.Mi);
+        Assert.Equal("06AB", data.AppData);
+    }
+
+    [Fact]
+    public void BuildData_CrcVerifies()
+    {
+        string packet = PacketCodec.BuildData(0, 0, "01", "05");
+        Assert.True(PacketCodec.VerifyCrc(packet));
+    }
+
+    [Fact]
+    public void BuildData_TamperedCrc_FailsVerify()
+    {
+        string packet = PacketCodec.BuildData(0, 0, "01", "05");
+        // flip a char in the appdata region (index 8 is MI high nibble)
+        char[] chars = packet.ToCharArray();
+        chars[8] = chars[8] == '0' ? '1' : '0';
+        Assert.False(PacketCodec.VerifyCrc(new string(chars)));
+    }
+
+    [Fact]
+    public void BuildAck_ParsesAsAck_WithNrAndAddr()
+    {
+        string ack = PacketCodec.BuildAck(nr: 3, addr: "01");
+        Assert.Equal(ProtocolConstants.ACK, ack[0]);
+        Assert.True(PacketCodec.TryParse(ack, out var data, out char kind));
+        Assert.Equal('A', kind);
+        Assert.Equal(3, data.Nr);
+        Assert.Equal("01", data.Addr);
+    }
+
+    [Fact]
+    public void TryParse_Garbage_ReturnsFalse()
+    {
+        Assert.False(PacketCodec.TryParse("not a packet", out _, out _));
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test tests/TSISP003.Tests/TSISP003.Tests.csproj --filter "FullyQualifiedName~PacketCodecTests"`
+Expected: FAIL — `PacketCodec` does not exist (compile error).
+
+- [ ] **Step 3: Implement `PacketCodec`**
+
+Create `src/TSISP003.Protocol/PacketCodec.cs`:
+
+```csharp
+using System.Text;
+
+namespace TSISP003.Protocol;
+
+public record DataPacket(int Ns, int Nr, string Addr, int Mi, string AppData);
+
+public static class PacketCodec
+{
+    public static string BuildData(int ns, int nr, string addr, string appDataWithMi)
+    {
+        string body = ProtocolConstants.SOH
+            + ns.ToString("X2") + nr.ToString("X2")
+            + addr
+            + ProtocolConstants.STX
+            + appDataWithMi;
+        return body
+            + ProtocolHelper.PacketCRC(Encoding.ASCII.GetBytes(body))
+            + ProtocolConstants.ETX;
+    }
+
+    public static string BuildAck(int nr, string addr) => BuildLink(ProtocolConstants.ACK, nr, addr);
+    public static string BuildNak(int nr, string addr) => BuildLink(ProtocolConstants.NAK, nr, addr);
+
+    private static string BuildLink(char control, int nr, string addr)
+    {
+        string body = control + nr.ToString("X2") + addr;
+        return body
+            + ProtocolHelper.PacketCRC(Encoding.ASCII.GetBytes(body))
+            + ProtocolConstants.ETX;
+    }
+
+    public static bool TryParse(string packet, out DataPacket data, out char kind)
+    {
+        data = new DataPacket(0, 0, string.Empty, 0, string.Empty);
+        kind = '?';
+        if (string.IsNullOrEmpty(packet) || packet[^1] != ProtocolConstants.ETX)
+            return false;
+
+        char start = packet[0];
+        if (start == ProtocolConstants.ACK || start == ProtocolConstants.NAK)
+        {
+            // control(1) + NR(2) + ADDR(2) + CRC(4) + ETX(1) = 10 chars
+            if (packet.Length < 10) return false;
+            kind = start == ProtocolConstants.ACK ? 'A' : 'N';
+            int lnr = Convert.ToInt32(packet[1..3], 16);
+            string laddr = packet[3..5];
+            data = new DataPacket(0, lnr, laddr, 0, string.Empty);
+            return true;
+        }
+
+        if (start == ProtocolConstants.SOH)
+        {
+            // SOH + NS(2)+NR(2)+ADDR(2) + STX + appdata + CRC(4) + ETX
+            if (packet.Length < 13 || packet[7] != ProtocolConstants.STX) return false;
+            int ns = Convert.ToInt32(packet[1..3], 16);
+            int nr = Convert.ToInt32(packet[3..5], 16);
+            string addr = packet[5..7];
+            string appData = packet[8..^5];
+            int mi = Convert.ToInt32(appData[0..2], 16);
+            kind = 'D';
+            data = new DataPacket(ns, nr, addr, mi, appData);
+            return true;
+        }
+
+        return false;
+    }
+
+    public static bool VerifyCrc(string packet)
+    {
+        if (string.IsNullOrEmpty(packet) || packet[^1] != ProtocolConstants.ETX) return false;
+        string body = packet[0..^5];          // everything except CRC(4) + ETX(1)
+        string crc = packet[^5..^1];
+        return ProtocolHelper.PacketCRC(Encoding.ASCII.GetBytes(body)) == crc;
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test tests/TSISP003.Tests/TSISP003.Tests.csproj --filter "FullyQualifiedName~PacketCodecTests"`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A && git commit -m "feat: add PacketCodec for TSISP003 frame build/parse"
+```
+
+---
+
+## Task 3: Simulator project skeleton + `SimulatorMemory`
+
+**Files:**
+- Create: `src/TSISP003.Simulator/TSISP003.Simulator.csproj`
+- Create: `src/TSISP003.Simulator/Storage/StoredItems.cs` (record types)
+- Create: `src/TSISP003.Simulator/Storage/SimulatorMemory.cs`
+- Create: `src/TSISP003.Simulator/Configuration/SimulatorOptions.cs`
+- Modify: `TSISP003-Net.slnx`
+- Test: `tests/TSISP003.Tests/Simulator/SimulatorMemoryTests.cs`
+
+**Interfaces:**
+- Produces:
+  - `record StoredTextFrame(byte FrameId, byte Revision, byte Font, byte Colour, byte Conspicuity, byte NumChars, string TextHex)`
+  - `record StoredGraphicsFrame(byte FrameId, byte Revision, byte Rows, byte Cols, byte Colour, byte Conspicuity, ushort Length, string DataHex)`
+  - `record StoredHiResFrame(byte FrameId, byte Revision, ushort Rows, ushort Cols, byte Colour, byte Conspicuity, uint Length, string DataHex)`
+  - `record StoredMessage(byte MessageId, byte Revision, byte TransitionTime, (byte Id, byte Time)[] Frames)`
+  - `record StoredPlanEntry(byte Type, byte Id, byte StartHour, byte StartMin, byte StopHour, byte StopMin)`
+  - `record StoredPlan(byte PlanId, byte Revision, byte DayOfWeek, StoredPlanEntry[] Entries)`
+  - `class SimulatorMemory` with `IDictionary` stores keyed by `byte` id for each of the above, plus mutable display state: `byte ActiveFrameId/ActiveFrameRevision/ActiveMessageId/ActiveMessageRevision/ActivePlanId/ActivePlanRevision`, `bool SignEnabled` (default true), and a thread-safe `object Gate`. Methods: `PutTextFrame`, `GetTextFrame(byte)→StoredTextFrame?`, etc.; `SetActiveFrame(byte id, byte rev)`, `SetActiveMessage(byte id, byte rev)`, `SetActivePlan(byte id, byte rev)`.
+  - `class SimulatorOptions { string Address {get;set;} = "01"; int Port {get;set;} = 5000; string SeedOffset {get;set;} = "00"; string PasswordOffset {get;set;} = "00"; byte Seed {get;set;} = 0x12; }`
+
+- [ ] **Step 1: Create the project**
+
+Create `src/TSISP003.Simulator/TSISP003.Simulator.csproj` mirroring `src/TSISP003.Api/TSISP003.Api.csproj`'s SDK style but as a worker/console. Reference the Generic Host packages (via CPM) and the Protocol project:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TSISP003.Protocol\TSISP003.Protocol.csproj" />
+  </ItemGroup>
+
+</Project>
+```
+
+Ensure `Microsoft.Extensions.Hosting` has a `<PackageVersion>` in `Directory.Packages.props` (add it at the version used by `TSISP003.ServiceDefaults`/`AppHost` if not present). Register the project in `TSISP003-Net.slnx` under `/src/`.
+
+Also add a ProjectReference so the test project can see Simulator types (needed from this task onward). In `tests/TSISP003.Tests/TSISP003.Tests.csproj`, add to the ProjectReferences `<ItemGroup>`:
+```xml
+<ProjectReference Include="..\..\src\TSISP003.Simulator\TSISP003.Simulator.csproj" />
+```
+(`TSISP003.Protocol` is then available transitively; the test files in later tasks `using TSISP003.Protocol;` directly, which works through the transitive reference.)
+
+- [ ] **Step 2: Write failing tests**
+
+Create `tests/TSISP003.Tests/Simulator/SimulatorMemoryTests.cs`:
+
+```csharp
+using TSISP003.Simulator.Storage;
+using Xunit;
+
+namespace TSISP003.Tests.Simulator;
+
+public class SimulatorMemoryTests
+{
+    [Fact]
+    public void PutThenGetTextFrame_ReturnsSameFrame()
+    {
+        var mem = new SimulatorMemory();
+        var frame = new StoredTextFrame(7, 1, 0, 0, 0, 5, "48454C4C4F"); // "HELLO"
+        mem.PutTextFrame(frame);
+
+        var got = mem.GetTextFrame(7);
+        Assert.Equal(frame, got);
+    }
+
+    [Fact]
+    public void GetTextFrame_Unknown_ReturnsNull()
+    {
+        var mem = new SimulatorMemory();
+        Assert.Null(mem.GetTextFrame(99));
+    }
+
+    [Fact]
+    public void SetActiveFrame_UpdatesDisplayState()
+    {
+        var mem = new SimulatorMemory();
+        mem.SetActiveFrame(7, 1);
+        Assert.Equal(7, mem.ActiveFrameId);
+        Assert.Equal(1, mem.ActiveFrameRevision);
+    }
+
+    [Fact]
+    public void SignEnabled_DefaultsTrue()
+    {
+        Assert.True(new SimulatorMemory().SignEnabled);
+    }
+}
+```
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `dotnet test tests/TSISP003.Tests/TSISP003.Tests.csproj --filter "FullyQualifiedName~SimulatorMemoryTests"`
+Expected: FAIL — types don't exist.
+
+- [ ] **Step 4: Implement the records and memory**
+
+Create `src/TSISP003.Simulator/Storage/StoredItems.cs`:
+
+```csharp
+namespace TSISP003.Simulator.Storage;
+
+public record StoredTextFrame(byte FrameId, byte Revision, byte Font, byte Colour, byte Conspicuity, byte NumChars, string TextHex);
+public record StoredGraphicsFrame(byte FrameId, byte Revision, byte Rows, byte Cols, byte Colour, byte Conspicuity, ushort Length, string DataHex);
+public record StoredHiResFrame(byte FrameId, byte Revision, ushort Rows, ushort Cols, byte Colour, byte Conspicuity, uint Length, string DataHex);
+public record StoredMessage(byte MessageId, byte Revision, byte TransitionTime, (byte Id, byte Time)[] Frames);
+public record StoredPlanEntry(byte Type, byte Id, byte StartHour, byte StartMin, byte StopHour, byte StopMin);
+public record StoredPlan(byte PlanId, byte Revision, byte DayOfWeek, StoredPlanEntry[] Entries);
+```
+
+Create `src/TSISP003.Simulator/Storage/SimulatorMemory.cs`:
+
+```csharp
+namespace TSISP003.Simulator.Storage;
+
+public class SimulatorMemory
+{
+    public object Gate { get; } = new();
+
+    private readonly Dictionary<byte, StoredTextFrame> _text = new();
+    private readonly Dictionary<byte, StoredGraphicsFrame> _graphics = new();
+    private readonly Dictionary<byte, StoredHiResFrame> _hiRes = new();
+    private readonly Dictionary<byte, StoredMessage> _messages = new();
+    private readonly Dictionary<byte, StoredPlan> _plans = new();
+
+    public byte ActiveFrameId { get; private set; }
+    public byte ActiveFrameRevision { get; private set; }
+    public byte ActiveMessageId { get; private set; }
+    public byte ActiveMessageRevision { get; private set; }
+    public byte ActivePlanId { get; private set; }
+    public byte ActivePlanRevision { get; private set; }
+    public bool SignEnabled { get; set; } = true;
+
+    public void PutTextFrame(StoredTextFrame f) => _text[f.FrameId] = f;
+    public StoredTextFrame? GetTextFrame(byte id) => _text.TryGetValue(id, out var f) ? f : null;
+
+    public void PutGraphicsFrame(StoredGraphicsFrame f) => _graphics[f.FrameId] = f;
+    public StoredGraphicsFrame? GetGraphicsFrame(byte id) => _graphics.TryGetValue(id, out var f) ? f : null;
+
+    public void PutHiResFrame(StoredHiResFrame f) => _hiRes[f.FrameId] = f;
+    public StoredHiResFrame? GetHiResFrame(byte id) => _hiRes.TryGetValue(id, out var f) ? f : null;
+
+    public void PutMessage(StoredMessage m) => _messages[m.MessageId] = m;
+    public StoredMessage? GetMessage(byte id) => _messages.TryGetValue(id, out var m) ? m : null;
+
+    public void PutPlan(StoredPlan p) => _plans[p.PlanId] = p;
+    public StoredPlan? GetPlan(byte id) => _plans.TryGetValue(id, out var p) ? p : null;
+
+    public void SetActiveFrame(byte id, byte rev) { ActiveFrameId = id; ActiveFrameRevision = rev; }
+    public void SetActiveMessage(byte id, byte rev) { ActiveMessageId = id; ActiveMessageRevision = rev; }
+    public void SetActivePlan(byte id, byte rev) { ActivePlanId = id; ActivePlanRevision = rev; }
+}
+```
+
+Create `src/TSISP003.Simulator/Configuration/SimulatorOptions.cs`:
+
+```csharp
+namespace TSISP003.Simulator.Configuration;
+
+public class SimulatorOptions
+{
+    public string Address { get; set; } = "01";
+    public int Port { get; set; } = 5000;
+    public string SeedOffset { get; set; } = "00";
+    public string PasswordOffset { get; set; } = "00";
+    public byte Seed { get; set; } = 0x12;
+}
+```
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `dotnet test tests/TSISP003.Tests/TSISP003.Tests.csproj --filter "FullyQualifiedName~SimulatorMemoryTests"`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A && git commit -m "feat: add Simulator project skeleton and in-memory store"
+```
+
+---
+
+## Task 4: `SimulatorReplyBuilder` — status & config replies
+
+**Files:**
+- Create: `src/TSISP003.Simulator/Protocol/SimulatorReplyBuilder.cs`
+- Test: `tests/TSISP003.Tests/Simulator/SimulatorReplyBuilderTests.cs`
+
+**Interfaces:**
+- Consumes: `SimulatorMemory`, `SimulatorOptions`, `ProtocolConstants`.
+- Produces: `class SimulatorReplyBuilder(SimulatorOptions options)` with pure methods returning **application-data hex strings (MI-prefixed, no framing)**:
+  - `string StatusReply(SimulatorMemory mem, DateTime now)` (MI 06)
+  - `string ConfigReply()` (MI 22)
+  - `string ReportEnabledPlans((byte group, byte plan)[] enabled)` (MI 13)
+  - `string Reject(int rejectedMi, byte appErrorCode)` (MI 00)
+  - `string Ack()` → `"01"`
+  - `string PasswordSeed()` → `"03" + options.Seed:X2`
+
+The single fixed sign uses `SignId = 0x01`, `SignType = 0` (text), width/height `48 x 18` (configurable later if needed).
+
+- [ ] **Step 1: Write failing tests** — assert the exact tricky encodings.
+
+Create `tests/TSISP003.Tests/Simulator/SimulatorReplyBuilderTests.cs`:
+
+```csharp
+using TSISP003.Simulator.Configuration;
+using TSISP003.Simulator.Protocol;
+using TSISP003.Simulator.Storage;
+using Xunit;
+
+namespace TSISP003.Tests.Simulator;
+
+public class SimulatorReplyBuilderTests
+{
+    private static SimulatorReplyBuilder NewBuilder() => new(new SimulatorOptions { Address = "01", Seed = 0x12 });
+
+    [Fact]
+    public void StatusReply_EncodesYearAsBigEndianWord_AndDecimalCountFields()
+    {
+        var mem = new SimulatorMemory();
+        mem.SetActiveFrame(7, 1);
+        var b = NewBuilder();
+
+        string app = b.StatusReply(mem, new DateTime(2025, 3, 4, 5, 6, 7));
+
+        Assert.Equal("06", app[0..2]);          // MI
+        Assert.Equal("01", app[2..4]);          // online
+        Assert.Equal("07E9", app[10..14]);      // year 2025 big-endian word
+        Assert.Equal("00", app[24..26]);        // controller error, decimal D2
+        Assert.Equal("01", app[26..28]);        // number of signs, decimal D2
+        // sign block (18 hex): SignID=01, err=00, enabled=01, frame=07, frameRev=01, msg=00, msgRev=00, plan=00, planRev=00
+        Assert.Equal("010001070100000000", app[28..46]);
+    }
+
+    [Fact]
+    public void Ack_IsMi01() => Assert.Equal("01", NewBuilder().Ack());
+
+    [Fact]
+    public void PasswordSeed_IsMi03PlusSeed() => Assert.Equal("0312", NewBuilder().PasswordSeed());
+
+    [Fact]
+    public void Reject_CarriesRejectedMiAndError()
+        => Assert.Equal("004005", NewBuilder().Reject(0x40, 5));
+
+    [Fact]
+    public void ConfigReply_HasOneGroupOneSign()
+    {
+        string app = NewBuilder().ConfigReply();
+        Assert.Equal("22", app[0..2]);
+        Assert.Equal("01", app[22..24]); // number of groups
+    }
+
+    [Fact]
+    public void ReportEnabledPlans_EncodesEntries()
+    {
+        string app = NewBuilder().ReportEnabledPlans(new[] { ((byte)1, (byte)5) });
+        Assert.Equal("13", app[0..2]);
+        Assert.Equal("01", app[2..4]);   // count
+        Assert.Equal("0105", app[4..8]); // group 1 plan 5
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `dotnet test tests/TSISP003.Tests/TSISP003.Tests.csproj --filter "FullyQualifiedName~SimulatorReplyBuilderTests"`
+Expected: FAIL — `SimulatorReplyBuilder` missing.
+
+- [ ] **Step 3: Implement the builder**
+
+Create `src/TSISP003.Simulator/Protocol/SimulatorReplyBuilder.cs`:
+
+```csharp
+using System.Text;
+using TSISP003.Simulator.Configuration;
+using TSISP003.Simulator.Storage;
+
+namespace TSISP003.Simulator.Protocol;
+
+public class SimulatorReplyBuilder(SimulatorOptions options)
+{
+    private const byte SignId = 0x01;
+    private const byte SignTypeText = 0x00;
+    private const ushort SignWidth = 48;
+    private const ushort SignHeight = 18;
+
+    public string Ack() => "01";
+
+    public string PasswordSeed() => "03" + options.Seed.ToString("X2");
+
+    public string Reject(int rejectedMi, byte appErrorCode)
+        => "00" + rejectedMi.ToString("X2") + appErrorCode.ToString("X2");
+
+    public string StatusReply(SimulatorMemory mem, DateTime now)
+    {
+        var sb = new StringBuilder();
+        sb.Append("06");                              // MI
+        sb.Append("01");                              // online
+        sb.Append("00");                              // application error code
+        sb.Append(((byte)now.Day).ToString("X2"));
+        sb.Append(((byte)now.Month).ToString("X2"));
+        sb.Append(((ushort)now.Year).ToString("X4")); // year as big-endian word
+        sb.Append(((byte)now.Hour).ToString("X2"));
+        sb.Append(((byte)now.Minute).ToString("X2"));
+        sb.Append(((byte)now.Second).ToString("X2"));
+        sb.Append("0000");                            // controller checksum (WORD, ignored by client)
+        sb.Append(0.ToString("D2"));                  // controller error code — DECIMAL
+        sb.Append(1.ToString("D2"));                  // number of signs — DECIMAL
+
+        lock (mem.Gate)
+        {
+            sb.Append(SignId.ToString("X2"));
+            sb.Append("00");                          // sign error code
+            sb.Append(mem.SignEnabled ? "01" : "00");
+            sb.Append(mem.ActiveFrameId.ToString("X2"));
+            sb.Append(mem.ActiveFrameRevision.ToString("X2"));
+            sb.Append(mem.ActiveMessageId.ToString("X2"));
+            sb.Append(mem.ActiveMessageRevision.ToString("X2"));
+            sb.Append(mem.ActivePlanId.ToString("X2"));
+            sb.Append(mem.ActivePlanRevision.ToString("X2"));
+        }
+        return sb.ToString();
+    }
+
+    public string ConfigReply()
+    {
+        var sb = new StringBuilder();
+        sb.Append("22");
+        sb.Append(new string('0', 20));               // 10-byte manufacturer code
+        sb.Append(1.ToString("X2"));                  // number of groups
+        sb.Append(1.ToString("X2"));                  // group id
+        sb.Append(1.ToString("X2"));                  // number of signs
+        sb.Append(SignId.ToString("X2"));
+        sb.Append(SignTypeText.ToString("X2"));
+        sb.Append(WordLoHi(SignWidth));
+        sb.Append(WordLoHi(SignHeight));
+        sb.Append("00");                              // signature length
+        return sb.ToString();
+    }
+
+    public string ReportEnabledPlans((byte group, byte plan)[] enabled)
+    {
+        var sb = new StringBuilder();
+        sb.Append("13");
+        sb.Append(((byte)enabled.Length).ToString("X2"));
+        foreach (var (group, plan) in enabled)
+        {
+            sb.Append(group.ToString("X2"));
+            sb.Append(plan.ToString("X2"));
+        }
+        return sb.ToString();
+    }
+
+    private static string WordLoHi(ushort value)
+        => ((byte)(value & 0xFF)).ToString("X2") + ((byte)(value >> 8)).ToString("X2");
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `dotnet test tests/TSISP003.Tests/TSISP003.Tests.csproj --filter "FullyQualifiedName~SimulatorReplyBuilderTests"`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A && git commit -m "feat: add SimulatorReplyBuilder for status/config/report replies"
+```
+
+---
+
+## Task 5: Set-command parsers → store in memory
+
+**Files:**
+- Create: `src/TSISP003.Simulator/Protocol/SetCommandParser.cs`
+- Test: `tests/TSISP003.Tests/Simulator/SetCommandParserTests.cs`
+
+**Interfaces:**
+- Consumes: `SimulatorMemory`, the `Stored*` records, `ProtocolHelper`.
+- Produces: `static class SetCommandParser` with, for each MI, a parse method taking the MI-prefixed appdata hex and returning the `Stored*` record:
+  - `StoredTextFrame ParseTextFrame(string appData)` — fields per the layout; `TextHex = appData[14..(14+NumChars*2)]`.
+  - `StoredGraphicsFrame ParseGraphicsFrame(string appData)` — length at `[14..18]` (WORD hex), data `[18..18+Length*2]`.
+  - `StoredHiResFrame ParseHiResFrame(string appData)` — rows `[6..10]`, cols `[10..14]`, colour `[14..16]`, consp `[16..18]`, length `[18..26]` (DWORD), data `[26..26+Length*2]`.
+  - `StoredMessage ParseMessage(string appData)` — 6 (id,time) pairs starting at `[6..]`.
+  - `StoredPlan ParsePlan(string appData)` — entries of 12 hex each from `[6..]`, stop at a `00` type terminator or end of data.
+- Also produce the inverse re-encoders used by Request-Stored in Task 6 (`BuildTextFrameAppData(StoredTextFrame)` etc.) — defined HERE so parser/encoder stay together:
+  - `string BuildTextFrameAppData(StoredTextFrame f)` reproducing the client's `SignSetTextFrame` body **including the embedded application CRC** (`PacketCRC(GetBytes(HexToAscii(appMsg)))`).
+  - `string BuildGraphicsFrameAppData(StoredGraphicsFrame f)` (embedded CRC).
+  - `string BuildHiResFrameAppData(StoredHiResFrame f)` (embedded CRC).
+  - `string BuildMessageAppData(StoredMessage m)` (no embedded CRC; pad to 6 frames with `0000`).
+  - `string BuildPlanAppData(StoredPlan p)` (no embedded CRC; trailing `00` if <6 entries).
+
+- [ ] **Step 1: Write failing tests** (round-trip parse↔build, the strongest guarantee).
+
+Create `tests/TSISP003.Tests/Simulator/SetCommandParserTests.cs`:
+
+```csharp
+using TSISP003.Simulator.Protocol;
+using TSISP003.Simulator.Storage;
+using Xunit;
+
+namespace TSISP003.Tests.Simulator;
+
+public class SetCommandParserTests
+{
+    [Fact]
+    public void TextFrame_BuildThenParse_RoundTrips()
+    {
+        var f = new StoredTextFrame(7, 1, 0, 0, 0, 5, "48454C4C4F"); // HELLO
+        string appData = SetCommandParser.BuildTextFrameAppData(f);
+
+        Assert.Equal("0A", appData[0..2]);
+        var parsed = SetCommandParser.ParseTextFrame(appData);
+        Assert.Equal(f, parsed);
+    }
+
+    [Fact]
+    public void GraphicsFrame_BuildThenParse_RoundTrips()
+    {
+        var f = new StoredGraphicsFrame(3, 2, 18, 48, 1, 0, 2, "ABCD");
+        string appData = SetCommandParser.BuildGraphicsFrameAppData(f);
+        Assert.Equal("0B", appData[0..2]);
+        Assert.Equal(f, SetCommandParser.ParseGraphicsFrame(appData));
+    }
+
+    [Fact]
+    public void HiResFrame_BuildThenParse_RoundTrips()
+    {
+        var f = new StoredHiResFrame(4, 1, 256, 512, 2, 0, 3, "AABBCC");
+        string appData = SetCommandParser.BuildHiResFrameAppData(f);
+        Assert.Equal("1D", appData[0..2]);
+        Assert.Equal(f, SetCommandParser.ParseHiResFrame(appData));
+    }
+
+    [Fact]
+    public void Message_BuildThenParse_RoundTrips()
+    {
+        var m = new StoredMessage(2, 1, 5, new (byte, byte)[] { (7, 10), (8, 10) });
+        string appData = SetCommandParser.BuildMessageAppData(m);
+        Assert.Equal("0C", appData[0..2]);
+        var parsed = SetCommandParser.ParseMessage(appData);
+        Assert.Equal((byte)2, parsed.MessageId);
+        Assert.Equal((7, 10), ((int)parsed.Frames[0].Id, (int)parsed.Frames[0].Time));
+        Assert.Equal((8, 10), ((int)parsed.Frames[1].Id, (int)parsed.Frames[1].Time));
+    }
+
+    [Fact]
+    public void Plan_BuildThenParse_RoundTrips()
+    {
+        var p = new StoredPlan(1, 1, 0x7F, new[] { new StoredPlanEntry(1, 7, 8, 0, 17, 30) });
+        string appData = SetCommandParser.BuildPlanAppData(p);
+        Assert.Equal("0D", appData[0..2]);
+        var parsed = SetCommandParser.ParsePlan(appData);
+        Assert.Equal((byte)1, parsed.PlanId);
+        Assert.Single(parsed.Entries);
+        Assert.Equal(p.Entries[0], parsed.Entries[0]);
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `dotnet test tests/TSISP003.Tests/TSISP003.Tests.csproj --filter "FullyQualifiedName~SetCommandParserTests"`
+Expected: FAIL — `SetCommandParser` missing.
+
+- [ ] **Step 3: Implement parser + encoder**
+
+Create `src/TSISP003.Simulator/Protocol/SetCommandParser.cs`:
+
+```csharp
+using System.Text;
+using TSISP003.Protocol;
+using TSISP003.Simulator.Storage;
+
+namespace TSISP003.Simulator.Protocol;
+
+public static class SetCommandParser
+{
+    private static byte B(string s, int start) => Convert.ToByte(s[start..(start + 2)], 16);
+    private static ushort W(string s, int start) => Convert.ToUInt16(s[start..(start + 4)], 16);
+    private static uint D(string s, int start) => Convert.ToUInt32(s[start..(start + 8)], 16);
+
+    // ---- Text Frame (MI 0A) ----
+    public static StoredTextFrame ParseTextFrame(string a)
+    {
+        byte numChars = B(a, 12);
+        string textHex = a[14..(14 + numChars * 2)];
+        return new StoredTextFrame(B(a, 2), B(a, 4), B(a, 6), B(a, 8), B(a, 10), numChars, textHex);
+    }
+
+    public static string BuildTextFrameAppData(StoredTextFrame f)
+    {
+        string app = "0A"
+            + f.FrameId.ToString("X2") + f.Revision.ToString("X2")
+            + f.Font.ToString("X2") + f.Colour.ToString("X2")
+            + f.Conspicuity.ToString("X2") + f.NumChars.ToString("X2")
+            + f.TextHex;
+        return app + EmbeddedCrc(app);
+    }
+
+    // ---- Graphics Frame (MI 0B) ----
+    public static StoredGraphicsFrame ParseGraphicsFrame(string a)
+    {
+        ushort len = W(a, 14);
+        string data = a[18..(18 + len * 2)];
+        return new StoredGraphicsFrame(B(a, 2), B(a, 4), B(a, 6), B(a, 8), B(a, 10), B(a, 12), len, data);
+    }
+
+    public static string BuildGraphicsFrameAppData(StoredGraphicsFrame f)
+    {
+        string app = "0B"
+            + f.FrameId.ToString("X2") + f.Revision.ToString("X2")
+            + f.Rows.ToString("X2") + f.Cols.ToString("X2")
+            + f.Colour.ToString("X2") + f.Conspicuity.ToString("X2")
+            + f.Length.ToString("X4") + f.DataHex;
+        return app + EmbeddedCrc(app);
+    }
+
+    // ---- Hi-Res Frame (MI 1D) ----
+    public static StoredHiResFrame ParseHiResFrame(string a)
+    {
+        uint len = D(a, 18);
+        string data = a[26..(26 + (int)len * 2)];
+        return new StoredHiResFrame(B(a, 2), B(a, 4), W(a, 6), W(a, 10), B(a, 14), B(a, 16), len, data);
+    }
+
+    public static string BuildHiResFrameAppData(StoredHiResFrame f)
+    {
+        string app = "1D"
+            + f.FrameId.ToString("X2") + f.Revision.ToString("X2")
+            + f.Rows.ToString("X4") + f.Cols.ToString("X4")
+            + f.Colour.ToString("X2") + f.Conspicuity.ToString("X2")
+            + f.Length.ToString("X8") + f.DataHex;
+        return app + EmbeddedCrc(app);
+    }
+
+    // ---- Message (MI 0C) ----
+    public static StoredMessage ParseMessage(string a)
+    {
+        byte id = B(a, 2), rev = B(a, 4), transition = B(a, 6);
+        var frames = new List<(byte, byte)>();
+        for (int i = 0; i < 6; i++)
+        {
+            int off = 8 + i * 4;
+            if (off + 4 > a.Length) break;
+            byte fid = B(a, off), ftime = B(a, off + 2);
+            if (fid == 0) continue;            // 0 id = unused slot
+            frames.Add((fid, ftime));
+        }
+        return new StoredMessage(id, rev, transition, frames.ToArray());
+    }
+
+    public static string BuildMessageAppData(StoredMessage m)
+    {
+        var sb = new StringBuilder();
+        sb.Append("0C");
+        sb.Append(m.MessageId.ToString("X2"));
+        sb.Append(m.Revision.ToString("X2"));
+        sb.Append(m.TransitionTime.ToString("X2"));
+        for (int i = 0; i < 6; i++)
+        {
+            if (i < m.Frames.Length)
+            {
+                sb.Append(m.Frames[i].Id.ToString("X2"));
+                sb.Append(m.Frames[i].Time.ToString("X2"));
+            }
+            else sb.Append("0000");
+        }
+        return sb.ToString();
+    }
+
+    // ---- Plan (MI 0D) ----
+    public static StoredPlan ParsePlan(string a)
+    {
+        byte id = B(a, 2), rev = B(a, 4), dow = B(a, 6);
+        var entries = new List<StoredPlanEntry>();
+        for (int i = 0; i < 6; i++)
+        {
+            int off = 8 + i * 12;
+            if (off + 12 > a.Length) break;
+            byte type = B(a, off);
+            if (type == 0) break;              // terminator
+            entries.Add(new StoredPlanEntry(type, B(a, off + 2), B(a, off + 4),
+                B(a, off + 6), B(a, off + 8), B(a, off + 10)));
+        }
+        return new StoredPlan(id, rev, dow, entries.ToArray());
+    }
+
+    public static string BuildPlanAppData(StoredPlan p)
+    {
+        var sb = new StringBuilder();
+        sb.Append("0D");
+        sb.Append(p.PlanId.ToString("X2"));
+        sb.Append(p.Revision.ToString("X2"));
+        sb.Append(p.DayOfWeek.ToString("X2"));
+        foreach (var e in p.Entries)
+        {
+            sb.Append(e.Type.ToString("X2"));
+            sb.Append(e.Id.ToString("X2"));
+            sb.Append(e.StartHour.ToString("X2"));
+            sb.Append(e.StartMin.ToString("X2"));
+            sb.Append(e.StopHour.ToString("X2"));
+            sb.Append(e.StopMin.ToString("X2"));
+        }
+        if (p.Entries.Length < 6) sb.Append("00");
+        return sb.ToString();
+    }
+
+    private static string EmbeddedCrc(string appHex)
+        => ProtocolHelper.PacketCRC(Encoding.ASCII.GetBytes(ProtocolHelper.HexToAscii(appHex)));
+}
+```
+
+Note: `ParseTextFrame`/etc. ignore the trailing embedded CRC because field lengths are known. The round-trip test passes because `Build` appends and `Parse` slices by length.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `dotnet test tests/TSISP003.Tests/TSISP003.Tests.csproj --filter "FullyQualifiedName~SetCommandParserTests"`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A && git commit -m "feat: add set-command parsers and re-encoders"
+```
+
+---
+
+## Task 6: `SimulatorSession` — state machine & dispatch
+
+**Files:**
+- Create: `src/TSISP003.Simulator/Session/SimulatorSession.cs`
+- Test: `tests/TSISP003.Tests/Simulator/SimulatorSessionTests.cs`
+
+**Interfaces:**
+- Consumes: `PacketCodec`, `SimulatorReplyBuilder`, `SetCommandParser`, `SimulatorMemory`, `SimulatorOptions`, `ProtocolConstants`, `ProtocolHelper.GetChunks`.
+- Produces: `class SimulatorSession(SimulatorMemory mem, SimulatorReplyBuilder replies, SimulatorOptions options, Func<DateTime> clock)` with:
+  - `IReadOnlyList<string> Handle(string incoming)` — feeds bytes through the buffered chunker and returns the list of packet strings to write back (link-ACKs and data replies), in order. Pure/synchronous so it is trivially testable; the TCP layer (Task 7) just writes them.
+  - Internal `enum State { Idle, SeedSent, Online }`, plus `int Ns/Nr` sequence tracking and `_incompleteBuffer`.
+
+**Behavior rules (per MI):**
+- Every well-formed master DATA packet → first emit a link-ACK (`BuildAck(nextNr, addr)`), then emit the MI-specific data reply (if any). Increment the simulator's `Ns` after sending a data reply (mirror `IncrementSequenceNumber`).
+- MI 02 (Start Session): emit link-ACK + data `PasswordSeed()`; state → SeedSent.
+- MI 04 (Password): emit link-ACK + data `Ack()`; state → Online.
+- MI 05 (Heartbeat): emit data `StatusReply(mem, clock())` (no separate link-ACK needed but emit one for consistency).
+- MI 21 (Config Request): emit data `ConfigReply()`.
+- MI 0A/0B/1D (set frame): parse, store, emit data `StatusReply`.
+- MI 0C (set message): parse, store, emit data `StatusReply`.
+- MI 0D (set plan): parse, store, emit data `StatusReply`.
+- MI 0E (display frame): `mem.SetActiveFrame(frameId, rev=storedRevOr0)`; emit data `Ack()`. (Frame revision: look up stored frame; if present use its revision, else 0.)
+- MI 0F (display message): `mem.SetActiveMessage(id, rev)`; emit `Ack()`.
+- MI 2B (display atomic): set active frame to the last (sign,frame) pair's frame; emit `StatusReply`.
+- MI 10 (enable plan): record enabled (group,plan) in a session set; `mem.SetActivePlan(planId, rev)`; emit `Ack()`.
+- MI 11 (disable plan): remove from enabled set; emit `Ack()`.
+- MI 12 (request enabled plans): emit `ReportEnabledPlans(currentEnabled)`.
+- MI 17 (request stored): look up by RequestType+id; emit the rebuilt set-command appdata, or `Reject(0x17, errorCode)` if not found.
+- MI 07 (end session): emit `Ack()`; state → Idle.
+- MI 08/09/14/15/16/1A/1B (supported-but-simple): emit `Ack()` (or for 1B Extended Status, emit a minimal status — to keep scope tight, emit `Reject(mi, code)` ONLY for truly out-of-scope MIs). Per the spec's response table, MI 1B expects MI 1C; since Extended Status is out of the Core-without-extended decision, reply `Reject(0x1B, errorCode)`.
+- Unsupported MIs (0x40–0x48 HAR, 0x80–0x87 weather, anything unknown): emit `Reject(mi, errorCode)`.
+- Use `ErrorCodes` from `Domain`? No — Simulator must not reference Domain. Define a local `const byte UnsupportedErrorCode = 0x03;` in the session (value not critical; client surfaces it in `SignRequestRejectedException`).
+
+- [ ] **Step 1: Write failing tests** (drive the handshake and a set→status round-trip).
+
+Create `tests/TSISP003.Tests/Simulator/SimulatorSessionTests.cs`:
+
+```csharp
+using TSISP003.Protocol;
+using TSISP003.Simulator.Configuration;
+using TSISP003.Simulator.Protocol;
+using TSISP003.Simulator.Session;
+using TSISP003.Simulator.Storage;
+using Xunit;
+
+namespace TSISP003.Tests.Simulator;
+
+public class SimulatorSessionTests
+{
+    private static SimulatorSession NewSession(SimulatorMemory mem)
+    {
+        var options = new SimulatorOptions { Address = "01", Seed = 0x12 };
+        return new SimulatorSession(mem, new SimulatorReplyBuilder(options), options,
+            () => new DateTime(2025, 1, 1, 0, 0, 0));
+    }
+
+    [Fact]
+    public void StartSession_RepliesAckAndPasswordSeed()
+    {
+        var session = NewSession(new SimulatorMemory());
+        string start = PacketCodec.BuildData(0, 0, "01", "02");
+
+        var outPackets = session.Handle(start);
+
+        Assert.Contains(outPackets, p => p[0] == ProtocolConstants.ACK);
+        Assert.Contains(outPackets, p =>
+            PacketCodec.TryParse(p, out var d, out var k) && k == 'D' && d.Mi == 0x03 && d.AppData == "0312");
+    }
+
+    [Fact]
+    public void Heartbeat_RepliesStatusReply()
+    {
+        var session = NewSession(new SimulatorMemory());
+        var heartbeat = PacketCodec.BuildData(0, 0, "01", "05");
+
+        var outPackets = session.Handle(heartbeat);
+
+        Assert.Contains(outPackets, p =>
+            PacketCodec.TryParse(p, out var d, out var k) && k == 'D' && d.Mi == 0x06);
+    }
+
+    [Fact]
+    public void SetTextFrame_StoresFrame_AndRepliesStatus()
+    {
+        var mem = new SimulatorMemory();
+        var session = NewSession(mem);
+        string appData = SetCommandParser.BuildTextFrameAppData(
+            new StoredTextFrame(7, 1, 0, 0, 0, 5, "48454C4C4F"));
+        var packet = PacketCodec.BuildData(0, 0, "01", appData);
+
+        var outPackets = session.Handle(packet);
+
+        Assert.NotNull(mem.GetTextFrame(7));
+        Assert.Contains(outPackets, p =>
+            PacketCodec.TryParse(p, out var d, out var k) && k == 'D' && d.Mi == 0x06);
+    }
+
+    [Fact]
+    public void DisplayFrame_MarksFrameActive_AndAcks()
+    {
+        var mem = new SimulatorMemory();
+        mem.PutTextFrame(new StoredTextFrame(7, 3, 0, 0, 0, 5, "48454C4C4F"));
+        var session = NewSession(mem);
+        var packet = PacketCodec.BuildData(0, 0, "01", "0E" + "01" + "07"); // group 1, frame 7
+
+        var outPackets = session.Handle(packet);
+
+        Assert.Equal(7, mem.ActiveFrameId);
+        Assert.Equal(3, mem.ActiveFrameRevision); // picked up from stored frame
+        Assert.Contains(outPackets, p =>
+            PacketCodec.TryParse(p, out var d, out var k) && k == 'D' && d.Mi == 0x01);
+    }
+
+    [Fact]
+    public void RequestStoredFrame_EchoesStoredFrame()
+    {
+        var mem = new SimulatorMemory();
+        mem.PutTextFrame(new StoredTextFrame(7, 1, 0, 0, 0, 5, "48454C4C4F"));
+        var session = NewSession(mem);
+        // RequestType 1 = Frame, id 7
+        var packet = PacketCodec.BuildData(0, 0, "01", "17" + "01" + "07");
+
+        var outPackets = session.Handle(packet);
+
+        Assert.Contains(outPackets, p =>
+            PacketCodec.TryParse(p, out var d, out var k) && k == 'D' && d.Mi == 0x0A);
+    }
+
+    [Fact]
+    public void UnsupportedMi_Rejects()
+    {
+        var session = NewSession(new SimulatorMemory());
+        var packet = PacketCodec.BuildData(0, 0, "01", "40"); // HAR status — out of scope
+
+        var outPackets = session.Handle(packet);
+
+        Assert.Contains(outPackets, p =>
+            PacketCodec.TryParse(p, out var d, out var k) && k == 'D' && d.Mi == 0x00);
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `dotnet test tests/TSISP003.Tests/TSISP003.Tests.csproj --filter "FullyQualifiedName~SimulatorSessionTests"`
+Expected: FAIL — `SimulatorSession` missing.
+
+- [ ] **Step 3: Confirm `RequestType` enum values**
+
+Run: `cat src/TSISP003.Domain/Enums/RequestType.cs`
+Use the integer values it defines for Frame/Message/Plan when mapping MI 17's RequestType byte. If Frame=1, Message=2, Plan=3 differ, adjust the `switch` in the implementation accordingly. (The simulator does NOT reference Domain — hard-code the confirmed integer values with a comment citing the enum.)
+
+- [ ] **Step 4: Implement the session**
+
+Create `src/TSISP003.Simulator/Session/SimulatorSession.cs`:
+
+```csharp
+using TSISP003.Protocol;
+using TSISP003.Simulator.Configuration;
+using TSISP003.Simulator.Protocol;
+using TSISP003.Simulator.Storage;
+
+namespace TSISP003.Simulator.Session;
+
+public class SimulatorSession(
+    SimulatorMemory mem,
+    SimulatorReplyBuilder replies,
+    SimulatorOptions options,
+    Func<DateTime> clock)
+{
+    private enum State { Idle, SeedSent, Online }
+
+    private const byte UnsupportedErrorCode = 0x03;
+    private const byte NotFoundErrorCode = 0x04;
+
+    // RequestType values per Domain/Enums/RequestType.cs (confirm in Step 3).
+    private const int RequestFrame = 1;
+    private const int RequestMessage = 2;
+    private const int RequestPlan = 3;
+
+    private State _state = State.Idle;
+    private int _ns;
+    private int _nr;
+    private string _buffer = string.Empty;
+    private readonly HashSet<(byte group, byte plan)> _enabledPlans = new();
+
+    public IReadOnlyList<string> Handle(string incoming)
+    {
+        var output = new List<string>();
+        _buffer += incoming;
+        var chunks = ProtocolHelper.GetChunks(_buffer, out string remaining);
+        _buffer = remaining;
+
+        foreach (var packet in chunks)
+        {
+            if (!PacketCodec.TryParse(packet, out var data, out char kind) || kind != 'D')
+                continue; // ignore link ACK/NAK and garbage from master
+
+            // Link-acknowledge the received data packet.
+            _nr = Increment(data.Ns);
+            output.Add(PacketCodec.BuildAck(_nr, options.Address));
+
+            string? reply = Dispatch(data);
+            if (reply is not null)
+            {
+                output.Add(PacketCodec.BuildData(_ns, _nr, options.Address, reply));
+                _ns = Increment(_ns);
+            }
+        }
+        return output;
+    }
+
+    private string? Dispatch(DataPacket data)
+    {
+        string a = data.AppData;
+        switch (data.Mi)
+        {
+            case ProtocolConstants.MI_START_SESSION:
+                _state = State.SeedSent;
+                return replies.PasswordSeed();
+
+            case ProtocolConstants.MI_PASSWORD:
+                _state = State.Online;
+                return replies.Ack();
+
+            case ProtocolConstants.MI_HEARTBEAT_POLL:
+                return replies.StatusReply(mem, clock());
+
+            case ProtocolConstants.MI_SIGN_CONFIGURATION_REQUEST:
+                return replies.ConfigReply();
+
+            case ProtocolConstants.MI_SIGN_SET_TEXT_FRAME:
+                mem.PutTextFrame(SetCommandParser.ParseTextFrame(a));
+                return replies.StatusReply(mem, clock());
+
+            case ProtocolConstants.MI_SIGN_SET_GRAPHIC_FRAME:
+                mem.PutGraphicsFrame(SetCommandParser.ParseGraphicsFrame(a));
+                return replies.StatusReply(mem, clock());
+
+            case ProtocolConstants.MI_SIGN_SET_HIGH_RESOLUTION_GRAPHICS_FRAME:
+                mem.PutHiResFrame(SetCommandParser.ParseHiResFrame(a));
+                return replies.StatusReply(mem, clock());
+
+            case ProtocolConstants.MI_SIGN_SET_MESSAGE:
+                mem.PutMessage(SetCommandParser.ParseMessage(a));
+                return replies.StatusReply(mem, clock());
+
+            case ProtocolConstants.MI_SIGN_SET_PLAN:
+                mem.PutPlan(SetCommandParser.ParsePlan(a));
+                return replies.StatusReply(mem, clock());
+
+            case ProtocolConstants.MI_SIGN_DISPLAY_FRAME:
+            {
+                byte frameId = Convert.ToByte(a[4..6], 16);
+                byte rev = mem.GetTextFrame(frameId)?.Revision
+                           ?? mem.GetGraphicsFrame(frameId)?.Revision
+                           ?? mem.GetHiResFrame(frameId)?.Revision ?? (byte)0;
+                mem.SetActiveFrame(frameId, rev);
+                return replies.Ack();
+            }
+
+            case ProtocolConstants.MI_SIGN_DISPLAY_MESSAGE:
+            {
+                byte msgId = Convert.ToByte(a[4..6], 16);
+                byte rev = mem.GetMessage(msgId)?.Revision ?? (byte)0;
+                mem.SetActiveMessage(msgId, rev);
+                return replies.Ack();
+            }
+
+            case ProtocolConstants.MI_SIGN_DISPLAY_ATOMIC_FRAMES:
+            {
+                byte numSigns = Convert.ToByte(a[4..6], 16);
+                if (numSigns > 0)
+                {
+                    int lastFrameOff = 6 + (numSigns - 1) * 4 + 2;
+                    byte frameId = Convert.ToByte(a[lastFrameOff..(lastFrameOff + 2)], 16);
+                    byte rev = mem.GetTextFrame(frameId)?.Revision ?? (byte)0;
+                    mem.SetActiveFrame(frameId, rev);
+                }
+                return replies.StatusReply(mem, clock());
+            }
+
+            case ProtocolConstants.MI_ENABLE_PLAN:
+            {
+                byte group = Convert.ToByte(a[2..4], 16);
+                byte planId = Convert.ToByte(a[4..6], 16);
+                _enabledPlans.Add((group, planId));
+                byte rev = mem.GetPlan(planId)?.Revision ?? (byte)0;
+                mem.SetActivePlan(planId, rev);
+                return replies.Ack();
+            }
+
+            case ProtocolConstants.MI_DISABLE_PLAN:
+            {
+                byte group = Convert.ToByte(a[2..4], 16);
+                byte planId = Convert.ToByte(a[4..6], 16);
+                _enabledPlans.Remove((group, planId));
+                return replies.Ack();
+            }
+
+            case ProtocolConstants.MI_REQUEST_ENABLED_PLANS:
+                return replies.ReportEnabledPlans(_enabledPlans.ToArray());
+
+            case ProtocolConstants.MI_SIGN_REQUEST_STORED_FRAME_MESSAGE_PLAN:
+                return RequestStored(a);
+
+            case ProtocolConstants.MI_END_SESSION:
+                _state = State.Idle;
+                return replies.Ack();
+
+            default:
+                return replies.Reject(data.Mi, UnsupportedErrorCode);
+        }
+    }
+
+    private string RequestStored(string a)
+    {
+        int requestType = Convert.ToInt32(a[2..4], 16);
+        byte id = Convert.ToByte(a[4..6], 16);
+
+        switch (requestType)
+        {
+            case RequestFrame:
+                if (mem.GetTextFrame(id) is { } tf) return SetCommandParser.BuildTextFrameAppData(tf);
+                if (mem.GetGraphicsFrame(id) is { } gf) return SetCommandParser.BuildGraphicsFrameAppData(gf);
+                if (mem.GetHiResFrame(id) is { } hf) return SetCommandParser.BuildHiResFrameAppData(hf);
+                break;
+            case RequestMessage:
+                if (mem.GetMessage(id) is { } m) return SetCommandParser.BuildMessageAppData(m);
+                break;
+            case RequestPlan:
+                if (mem.GetPlan(id) is { } p) return SetCommandParser.BuildPlanAppData(p);
+                break;
+        }
+        return replies.Reject(ProtocolConstants.MI_SIGN_REQUEST_STORED_FRAME_MESSAGE_PLAN, NotFoundErrorCode);
+    }
+
+    private static int Increment(int current) => current is 0 or >= 255 ? 1 : current + 1;
+}
+```
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `dotnet test tests/TSISP003.Tests/TSISP003.Tests.csproj --filter "FullyQualifiedName~SimulatorSessionTests"`
+Expected: PASS (6 tests). If `RequestStoredFrame_EchoesStoredFrame` fails on MI mapping, re-check Step 3 enum values.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A && git commit -m "feat: add SimulatorSession protocol state machine and dispatch"
+```
+
+---
+
+## Task 7: TCP listener + host + config + manual end-to-end verification
+
+**Files:**
+- Create: `src/TSISP003.Simulator/Tcp/SimulatorListener.cs`
+- Create: `src/TSISP003.Simulator/Program.cs`
+- Create: `src/TSISP003.Simulator/appsettings.json`
+- Test: `tests/TSISP003.Tests/Simulator/SimulatorListenerTests.cs`
+
+**Interfaces:**
+- Consumes: `SimulatorSession`, `SimulatorMemory`, `SimulatorReplyBuilder`, `SimulatorOptions`, `BackgroundService`, `TcpListener`.
+- Produces: `class SimulatorListener : BackgroundService` that accepts connections and, per connection, reads ASCII, feeds `SimulatorSession.Handle`, writes each returned packet back. One `SimulatorMemory` shared across the process (so stored items persist across reconnects within a run); one `SimulatorSession` per connection.
+
+- [ ] **Step 1: Write a failing integration test** (real loopback socket round-trip of the handshake).
+
+Create `tests/TSISP003.Tests/Simulator/SimulatorListenerTests.cs`:
+
+```csharp
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using Microsoft.Extensions.Logging.Abstractions;
+using TSISP003.Protocol;
+using TSISP003.Simulator.Configuration;
+using TSISP003.Simulator.Tcp;
+using Xunit;
+
+namespace TSISP003.Tests.Simulator;
+
+public class SimulatorListenerTests
+{
+    [Fact]
+    public async Task StartSession_OverRealSocket_ReturnsSeed()
+    {
+        var options = new SimulatorOptions { Address = "01", Port = 0, Seed = 0x12 };
+        using var listener = new SimulatorListener(options, NullLogger<SimulatorListener>.Instance);
+        listener.Start();
+        int port = listener.BoundPort;
+
+        using var client = new TcpClient();
+        await client.ConnectAsync(IPAddress.Loopback, port);
+        var stream = client.GetStream();
+
+        string start = PacketCodec.BuildData(0, 0, "01", "02");
+        byte[] outBytes = Encoding.ASCII.GetBytes(start);
+        await stream.WriteAsync(outBytes);
+
+        var buffer = new byte[1024];
+        int read = await stream.ReadAsync(buffer);
+        string response = Encoding.ASCII.GetString(buffer, 0, read);
+
+        // Response should contain the password-seed data packet "0312".
+        Assert.Contains("0312", response);
+
+        await listener.StopAsync(default);
+    }
+}
+```
+
+The test uses two members not on a plain `BackgroundService`: a synchronous `Start()` and a `BoundPort`. Provide them in the implementation (Step 3): `Start()` calls `StartAsync(default)`; `BoundPort` returns the `TcpListener`'s actual bound port (works with `Port = 0`).
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `dotnet test tests/TSISP003.Tests/TSISP003.Tests.csproj --filter "FullyQualifiedName~SimulatorListenerTests"`
+Expected: FAIL — `SimulatorListener` missing.
+
+- [ ] **Step 3: Implement the listener**
+
+Create `src/TSISP003.Simulator/Tcp/SimulatorListener.cs`:
+
+```csharp
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using TSISP003.Simulator.Configuration;
+using TSISP003.Simulator.Protocol;
+using TSISP003.Simulator.Session;
+using TSISP003.Simulator.Storage;
+
+namespace TSISP003.Simulator.Tcp;
+
+public class SimulatorListener(SimulatorOptions options, ILogger<SimulatorListener> logger)
+    : BackgroundService
+{
+    private readonly TcpListener _listener = new(IPAddress.Any, options.Port);
+    private readonly SimulatorMemory _memory = new();
+
+    public int BoundPort => ((IPEndPoint)_listener.LocalEndpoint).Port;
+
+    public void Start() => _listener.Start();
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!_listener.Server.IsBound) _listener.Start();
+        logger.LogInformation("TSISP003 simulator listening on port {Port}", BoundPort);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            TcpClient client;
+            try { client = await _listener.AcceptTcpClientAsync(stoppingToken); }
+            catch (OperationCanceledException) { break; }
+
+            _ = HandleClientAsync(client, stoppingToken);
+        }
+    }
+
+    private async Task HandleClientAsync(TcpClient client, CancellationToken token)
+    {
+        var replies = new SimulatorReplyBuilder(options);
+        var session = new SimulatorSession(_memory, replies, options, () => DateTime.Now);
+        using (client)
+        {
+            var stream = client.GetStream();
+            var buffer = new byte[4096];
+            try
+            {
+                int read;
+                while ((read = await stream.ReadAsync(buffer, token)) > 0)
+                {
+                    string incoming = Encoding.ASCII.GetString(buffer, 0, read);
+                    foreach (var packet in session.Handle(incoming))
+                    {
+                        byte[] outBytes = Encoding.ASCII.GetBytes(packet);
+                        await stream.WriteAsync(outBytes, token);
+                    }
+                }
+            }
+            catch (Exception ex) when (ex is IOException or OperationCanceledException)
+            {
+                logger.LogDebug("Client disconnected: {Message}", ex.Message);
+            }
+        }
+    }
+
+    public override void Dispose()
+    {
+        _listener.Dispose();
+        base.Dispose();
+    }
+}
+```
+
+- [ ] **Step 4: Create the host entrypoint and config**
+
+Create `src/TSISP003.Simulator/Program.cs`:
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using TSISP003.Simulator.Configuration;
+using TSISP003.Simulator.Tcp;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+var options = new SimulatorOptions();
+builder.Configuration.GetSection("Simulator").Bind(options);
+builder.Services.AddSingleton(options);
+builder.Services.AddHostedService<SimulatorListener>();
+
+await builder.Build().RunAsync();
+```
+
+Create `src/TSISP003.Simulator/appsettings.json`:
+
+```json
+{
+  "Simulator": {
+    "Address": "01",
+    "Port": 5000,
+    "SeedOffset": "00",
+    "PasswordOffset": "00",
+    "Seed": 18
+  }
+}
+```
+
+Ensure the csproj copies appsettings to output. Add to `src/TSISP003.Simulator/TSISP003.Simulator.csproj`:
+```xml
+<ItemGroup>
+  <None Update="appsettings.json" CopyToOutputDirectory="PreserveNewest" />
+</ItemGroup>
+```
+Also add `<PackageReference Include="Microsoft.Extensions.Configuration.Json" />` and `<PackageReference Include="Microsoft.Extensions.Configuration.Binder" />` if not transitively available (build will tell you). Add their `<PackageVersion>` to `Directory.Packages.props` if missing.
+
+`SimulatorListener` is constructed by DI which provides `ILogger<SimulatorListener>` automatically; no extra registration needed.
+
+- [ ] **Step 5: Run to verify the integration test passes**
+
+Run: `dotnet test tests/TSISP003.Tests/TSISP003.Tests.csproj --filter "FullyQualifiedName~SimulatorListenerTests"`
+Expected: PASS (1 test).
+
+- [ ] **Step 6: Full solution build & test**
+
+Run: `dotnet build TSISP003-Net.slnx`
+Expected: Build succeeded, 0 errors.
+
+Run: `dotnet test TSISP003-Net.slnx`
+Expected: ALL tests pass (existing + new).
+
+- [ ] **Step 7: Manual end-to-end against the real client**
+
+In terminal A:
+```bash
+dotnet run --project src/TSISP003.Simulator
+```
+Expected log: `TSISP003 simulator listening on port 5000`.
+
+Point the API's device config at the simulator (edit `src/TSISP003.Api/appsettings.Development.json` `SignControllerServices.Devices` so one device has `IpAddress: 127.0.0.1`, `Port: 5000`, `Address: 01`, `SeedOffset: 00`, `PasswordOffset: 00`). In terminal B:
+```bash
+dotnet run --project src/TSISP003.Api
+```
+Expected: API logs `Session started successfully` then `Sign configuration received: 1 groups`, and heartbeats proceed without errors. Use Swagger (`/swagger`) to POST a SetTextFrame to that device; expect HTTP 200 and a status reply. Then call RequestStored for that frame id; expect the same text back.
+
+Record the observed outcome (success/log excerpts) in the commit message.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add -A
+git commit -m "feat: add TCP listener and host for TSISP003 simulator"
+```
+
+---
+
+## Self-Review Notes (for the implementer)
+
+- **Spec coverage:** session handshake (Task 6), set text/graphics/hires/message/plan (Tasks 5–6), display frame/message/atomic (Task 6), enable/disable/request plans (Task 6), status & config replies (Task 4), request-stored echo (Tasks 5–6), reject for HAR/weather/unknown (Task 6), in-memory store (Task 3), shared protocol code (Task 1), TCP host (Task 7). All spec sections map to a task.
+- **Decimal-vs-hex trap:** Status Reply controller-error-code and sign-count are decimal (`D2`); year is a 4-hex big-endian word. Covered by `SimulatorReplyBuilderTests`.
+- **Embedded application CRC:** text/graphics/hires set commands carry an inner CRC over `HexToAscii(appdata)`. The simulator parses by fixed lengths (ignoring it) and reproduces it on re-encode. Covered by `SetCommandParserTests` round-trips.
+- **No silent caps:** message parser reads 6 slots, plan parser stops at a `00`-type terminator — both match the client encoder.
+- **If a reply fails to parse on the real client during Task 7 manual test:** capture the raw bytes the client received (`ProtocolHelper.PrintMessagePacket` debug logs) and diff against the layout table at the top of this plan before changing code.

--- a/Docs/superpowers/specs/2026-06-18-tsisp003-simulator-design.md
+++ b/Docs/superpowers/specs/2026-06-18-tsisp003-simulator-design.md
@@ -1,0 +1,105 @@
+# TSISP003 Simulator — Design
+
+**Date:** 2026-06-18
+**Status:** Approved (initial)
+
+## Goal
+
+Build a simulator for the TSI-SP-003 protocol: a TCP **server** that impersonates a
+roadside sign controller (the "slave"). It accepts the protocol's "set" commands from
+the existing client, stores frames/messages/plans **in local (in-memory) memory**, tracks
+display state, and answers status/request-stored queries — so the real `TSISP003.Api`
+client can connect to it and round-trip data end-to-end without physical hardware.
+
+## Scope
+
+**In scope (Core):** session handshake (start / password / heartbeat / end), the "set"
+commands (text frame, graphics frame, hi-res graphics frame, message, plan), display
+commands (frame, message, atomic), enable/disable plan + request-enabled-plans,
+status / extended-status / configuration replies, and request-stored-frame/message/plan.
+
+**Out of scope:** HAR audio (voice/strategy/plan) and environmental/weather messages —
+these MI codes are answered with a `RejectReply`. No fault injection. No disk persistence
+(in-memory only; cleared on restart).
+
+## Authoritative reference
+
+Byte-level layouts validated against the spec in `docs/`:
+`docs/06_message_summary_table.txt`, `docs/03_app_messages_1_to_20.txt`,
+`docs/04_app_messages_21_to_35.txt`, `docs/05_app_messages_36_to_51.txt`,
+`docs/02_datalink_layer.txt`, and the source PDF `TS 03644`.
+
+## Architecture & project layout
+
+Two new projects plus one refactor:
+
+```
+src/
+  TSISP003.Protocol/        NEW — shared protocol primitives
+      ProtocolConstants.cs    (MOVED from Infrastructure/Protocol)
+      ProtocolHelper.cs       (MOVED from Infrastructure/Protocol: CRC, password, hex, GetChunks)
+      PacketCodec.cs          NEW — build/parse SOH & ACK/NAK frames; extract N(S)/N(R)/ADDR/MI/data
+  TSISP003.Infrastructure/  references TSISP003.Protocol (drops its own copy)
+  TSISP003.Simulator/       NEW — simulated sign controller (console / BackgroundService host)
+  TSISP003.Api/
+```
+
+Moving `ProtocolHelper`/`ProtocolConstants` into a shared `TSISP003.Protocol` library means
+the real client and the simulator frame packets, compute CRCs, and derive passwords with the
+*same code* — guaranteeing wire-format agreement. Infrastructure behaviour is unchanged; only
+the `using` namespace updates.
+
+## Components (in TSISP003.Simulator)
+
+- **`SimulatorTcpListener`** — `TcpListener` accepting connections, one `SimulatorSession`
+  per client. Hosted as a `BackgroundService` so `dotnet run` starts it.
+- **`SimulatorSession`** — per-connection state machine + read buffer. Reuses
+  `ProtocolHelper.GetChunks` for partial-packet buffering. States: `Idle → SeedSent → Online`.
+- **`MessageDispatcher`** — decodes MI via `PacketCodec`, routes to a handler, manages
+  slave-side N(S)/N(R) and ACK emission (mirrors the client's increment rules).
+- **`SimulatorMemory`** — the "local memory": dictionaries keyed by id for text frames,
+  graphics frames, hi-res frames, messages, and plans; plus current display state (active
+  frame/message/plan id + revision) for the single sign. In-memory only.
+- **Handlers** — one method per supported MI (Core set). HAR & weather MIs → `RejectReply`.
+
+## Device model (fixed)
+
+Hard-coded: **1 group, 1 sign, text type, online.** Configuration / extended-status / status
+replies are assembled from this fixed layout combined with live memory state.
+
+## Data flow (worked example)
+
+```
+client → StartSession (MI 02)     sim → ACK, then PasswordSeed (MI 03, deterministic seed)
+client → Password    (MI 04)      sim → validate via GeneratePassword; ACK + AckMsg (MI 01)
+client → Heartbeat   (MI 05)      sim → SignStatusReply (MI 06) built from memory
+client → SetTextFrame(MI 0A)      sim → store frame[id]; ACK + StatusReply
+client → DisplayFrame(MI 0E)      sim → mark frame active on sign; ACK + StatusReply
+client → RequestStored(MI 17)     sim → echo stored frame back (MI 0A payload)
+```
+
+The seed sent in MI 03 is deterministic (nondeterministic RNG is unnecessary); the client
+computes the password from whatever seed is sent, and the simulator validates against the
+same `GeneratePassword` computation.
+
+## Error handling
+
+- Bad CRC / unparseable frame → `NAK` with current N(R).
+- Unknown / unsupported MI → `RejectReply` (MI 00) carrying the rejected MI + an `ErrorCodes` value.
+- Malformed "set" payload → `RejectReply` with the appropriate application error code.
+
+## Testing
+
+In `tests/TSISP003.Tests`:
+- `PacketCodec` round-trip tests (build → parse).
+- Password / CRC parity tests against the shared `ProtocolHelper`.
+- Handler tests: SetTextFrame then RequestStored returns identical bytes; DisplayFrame is
+  reflected in the next StatusReply.
+- Byte layouts cross-checked against `docs/06_message_summary_table.txt` and app-message specs.
+
+## Non-goals / YAGNI
+
+- No HAR or weather implementation (reject only).
+- No fault injection, no offline simulation toggles.
+- No persistence across restarts.
+- No multi-device / configurable layout (single fixed group+sign).

--- a/TSISP003-Net.slnx
+++ b/TSISP003-Net.slnx
@@ -5,6 +5,7 @@
     <Project Path="src/TSISP003.Application/TSISP003.Application.csproj" />
     <Project Path="src/TSISP003.Infrastructure/TSISP003.Infrastructure.csproj" />
     <Project Path="src/TSISP003.Api/TSISP003.Api.csproj" />
+    <Project Path="src/TSISP003.Simulator/TSISP003.Simulator.csproj" />
     <Project Path="src/TSISP003.AppHost/TSISP003.AppHost.csproj" />
     <Project Path="src/TSISP003.ServiceDefaults/TSISP003.ServiceDefaults.csproj" />
   </Folder>

--- a/TSISP003-Net.slnx
+++ b/TSISP003-Net.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/src/">
+    <Project Path="src/TSISP003.Protocol/TSISP003.Protocol.csproj" />
     <Project Path="src/TSISP003.Domain/TSISP003.Domain.csproj" />
     <Project Path="src/TSISP003.Application/TSISP003.Application.csproj" />
     <Project Path="src/TSISP003.Infrastructure/TSISP003.Infrastructure.csproj" />

--- a/aspire.config.json
+++ b/aspire.config.json
@@ -1,0 +1,5 @@
+{
+  "appHost": {
+    "path": "src/TSISP003.AppHost/TSISP003.AppHost.csproj"
+  }
+}

--- a/src/TSISP003.Api/Controllers/DevicesController.cs
+++ b/src/TSISP003.Api/Controllers/DevicesController.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using TSISP003.Application.DTOs;
+using TSISP003.Infrastructure.Configuration;
+
+namespace TSISP003.Api.Controllers;
+
+/// <summary>
+/// Lists the sign controller devices defined in configuration.
+/// </summary>
+[ApiController]
+[Route("api")]
+public class DevicesController(IOptions<SignControllerServiceOptions> options) : ControllerBase
+{
+    private readonly SignControllerServiceOptions _options = options.Value;
+
+    /// <summary>Returns every configured device (name, protocol address, host, port).</summary>
+    [HttpGet]
+    [Route("devices")]
+    public ActionResult<IEnumerable<DeviceInfoDto>> GetDevices()
+    {
+        var devices = _options.Devices
+            .Select(kvp => new DeviceInfoDto
+            {
+                Name = kvp.Key,
+                Address = kvp.Value.Address,
+                IpAddress = kvp.Value.IpAddress,
+                Port = kvp.Value.Port
+            })
+            .OrderBy(d => d.Name)
+            .ToList();
+
+        return Ok(devices);
+    }
+}

--- a/src/TSISP003.Api/Controllers/ExtendedController.cs
+++ b/src/TSISP003.Api/Controllers/ExtendedController.cs
@@ -1,0 +1,83 @@
+using Microsoft.AspNetCore.Mvc;
+using TSISP003.Application.DTOs;
+using TSISP003.Application.Interfaces;
+using TSISP003.Application.Mapping;
+using TSISP003.Domain.Exceptions;
+
+namespace TSISP003.Api.Controllers;
+
+/// <summary>
+/// Extended (non-protocol) management operations layered on top of TSI-SP-003.
+/// These are conveniences built from protocol primitives, not part of the protocol itself.
+/// </summary>
+[ApiController]
+[Route("api")]
+public class ExtendedController(
+    ILogger<ExtendedController> logger,
+    ISignControllerServiceFactory signControllerServiceFactory,
+    IExtendedSignService extendedSignService) : ControllerBase
+{
+    private readonly ILogger<ExtendedController> _logger = logger;
+    private readonly ISignControllerServiceFactory _signControllerServiceFactory = signControllerServiceFactory;
+    private readonly IExtendedSignService _extendedSignService = extendedSignService;
+
+    /// <summary>
+    /// Builds text frames from the request, assembles them into a message, and displays it.
+    /// </summary>
+    [HttpPost]
+    [Route("{device}/extended/request")]
+    public async Task<IActionResult> ExtendedRequestMessage(string device, [FromBody] ExtendedRequestMessageDto extendedRequestMessage)
+    {
+        try
+        {
+            if (!_signControllerServiceFactory.ContainsSignController(device))
+                return NotFound("Device not found");
+
+            await _extendedSignService.BuildAndDisplayMessageAsync(device, extendedRequestMessage);
+
+            return Ok();
+        }
+        catch (TimeoutException ex)
+        {
+            _logger.LogWarning(ex, "Extended request message timed out for device {Device}", device);
+            return StatusCode(StatusCodes.Status408RequestTimeout, "Extended request message timed out.");
+        }
+        catch (SignRequestRejectedException ex)
+        {
+            _logger.LogError("Extended request message rejected: {ErrorCode}", ex.RejectReply.ApplicationErrorCode);
+            return StatusCode(StatusCodes.Status400BadRequest, ex.RejectReply.AsDto());
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error processing extended request message for device {Device}", device);
+            return StatusCode(StatusCodes.Status500InternalServerError, "Error processing extended request message.");
+        }
+    }
+
+    /// <summary>
+    /// Returns the device's sign status, enriched with the resolved content (frames and decoded
+    /// text) of each sign's active message/frame.
+    /// </summary>
+    [HttpGet]
+    [Route("{device}/extended/status")]
+    public async Task<IActionResult> StatusRequestExtended(string device)
+    {
+        try
+        {
+            if (!_signControllerServiceFactory.ContainsSignController(device))
+                return NotFound("Device not found");
+
+            var status = await _extendedSignService.GetExtendedStatusAsync(device);
+
+            if (status is null)
+                return NotFound("Status not available");
+
+            return Ok(status);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error requesting extended status for device {Device}", device);
+            return StatusCode(StatusCodes.Status500InternalServerError, "Error requesting status.");
+        }
+    }
+}

--- a/src/TSISP003.Api/Controllers/StatusController.cs
+++ b/src/TSISP003.Api/Controllers/StatusController.cs
@@ -48,34 +48,6 @@ public class StatusController(ILogger<StatusController> logger, ISignControllerS
     }
 
     [HttpGet]
-    [Route("{device}/extended/status")]
-    public async Task<IActionResult> StatusRequestExtended(string device)
-    {
-        try
-        {
-            if (!_signControllerServiceFactory.ContainsSignController(device))
-                return NotFound("Device not found");
-
-            var controller = await _signControllerServiceFactory.GetSignControllerService(device).GetStatus();
-
-            if (controller is null)
-                return NotFound("Status not available");
-
-            return Ok(controller.AsDto());
-        }
-        catch (TimeoutException ex)
-        {
-            _logger.LogWarning(ex, "Sign Status Request timed out for device {Device}", device);
-            return StatusCode(StatusCodes.Status408RequestTimeout, "Sign Status Request timed out.");
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error requesting status for device {Device}", device);
-            return StatusCode(StatusCodes.Status500InternalServerError, "Error requesting status.");
-        }
-    }
-
-    [HttpGet]
     [Route("{device}/RetrieveFaultLog")]
     public async Task<IActionResult> RetrieveFaultLog(string device)
     {

--- a/src/TSISP003.Api/Controllers/SystemController.cs
+++ b/src/TSISP003.Api/Controllers/SystemController.cs
@@ -1,16 +1,13 @@
-using System.Collections.Concurrent;
-using System.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 using TSISP003.Application.DTOs;
 using TSISP003.Application.Interfaces;
 using TSISP003.Application.Mapping;
-using TSISP003.Domain.Entities;
 using TSISP003.Domain.Exceptions;
 
 namespace TSISP003.Api.Controllers;
 
 /// <summary>
-/// Handles system-level operations: reset, time update, and extended request messages.
+/// Handles system-level operations: reset and time update.
 /// </summary>
 [ApiController]
 [Route("api")]
@@ -18,21 +15,6 @@ public class SystemController(ILogger<SystemController> logger, ISignControllerS
 {
     private readonly ILogger<SystemController> _logger = logger;
     private readonly ISignControllerServiceFactory _signControllerServiceFactory = signControllerServiceFactory;
-
-    // Rolling ID management for ExtendedRequestMessage (per device)
-    private static readonly ConcurrentDictionary<string, int> _deviceIds = new();
-    private const byte MinId = 120;
-    private const byte MaxId = 254;
-
-    private static byte GetNextId(string device)
-    {
-        var newId = _deviceIds.AddOrUpdate(
-            device,
-            MinId,
-            (_, currentId) => currentId >= MaxId ? MinId : currentId + 1
-        );
-        return (byte)newId;
-    }
 
     /// <summary>
     /// Resets the system for the specified device.
@@ -112,178 +94,5 @@ public class SystemController(ILogger<SystemController> logger, ISignControllerS
             _logger.LogError(ex, "Error updating time for device {Device}", device);
             return StatusCode(StatusCodes.Status500InternalServerError, "Error updating time.");
         }
-    }
-
-    [HttpPost]
-    [Route("{device}/extended/request")]
-    public async Task<IActionResult> ExtendedRequestMessage(string device, [FromBody] ExtendedRequestMessageDto extendedRequestMessage)
-    {
-        // Create a new Stopwatch instance
-        Stopwatch stopwatch = new Stopwatch();
-
-        // Start measuring time
-        stopwatch.Start();
-
-        try
-        {
-
-            if (!_signControllerServiceFactory.ContainsSignController(device))
-                return NotFound("Device not found");
-
-            var controllerService = _signControllerServiceFactory.GetSignControllerService(device);
-
-            SignSetMessageDto signSetMessage = new SignSetMessageDto
-            {
-                MessageID = GetNextId(device)
-            };
-
-            if (extendedRequestMessage.Frame1 != null)
-            {
-                signSetMessage.Frame1Time = (byte)(extendedRequestMessage.Frame1Time * 10);
-
-                SignSetTextFrameDto signSetTextFrame1 = new SignSetTextFrameDto
-                {
-                    FrameID = GetNextId(device),
-                    Revision = 0,
-                    Font = extendedRequestMessage.Frame1.Font,
-                    Colour = extendedRequestMessage.Frame1.Colour,
-                    Conspicuity = extendedRequestMessage.Frame1.Conspicuity,
-                    Text = extendedRequestMessage.Frame1.Text
-                };
-
-                signSetMessage.Frame1ID = signSetTextFrame1.FrameID;
-
-                await controllerService.SignSetTextFrame(signSetTextFrame1.AsEntity());
-            }
-
-            if (extendedRequestMessage.Frame2 != null)
-            {
-                signSetMessage.Frame2Time = (byte)(extendedRequestMessage.Frame2Time * 10);
-
-                SignSetTextFrameDto signSetTextFrame2 = new SignSetTextFrameDto
-                {
-                    FrameID = GetNextId(device),
-                    Revision = 0,
-                    Font = extendedRequestMessage.Frame2.Font,
-                    Colour = extendedRequestMessage.Frame2.Colour,
-                    Conspicuity = extendedRequestMessage.Frame2.Conspicuity,
-                    Text = extendedRequestMessage.Frame2.Text
-                };
-
-                signSetMessage.Frame2ID = signSetTextFrame2.FrameID;
-
-                await controllerService.SignSetTextFrame(signSetTextFrame2.AsEntity());
-            }
-
-            if (extendedRequestMessage.Frame3 != null)
-            {
-                signSetMessage.Frame3Time = (byte)(extendedRequestMessage.Frame3Time * 10);
-
-                SignSetTextFrameDto signSetTextFrame3 = new SignSetTextFrameDto
-                {
-                    FrameID = GetNextId(device),
-                    Revision = 0,
-                    Font = extendedRequestMessage.Frame3.Font,
-                    Colour = extendedRequestMessage.Frame3.Colour,
-                    Conspicuity = extendedRequestMessage.Frame3.Conspicuity,
-                    Text = extendedRequestMessage.Frame3.Text
-                };
-
-                signSetMessage.Frame3ID = signSetTextFrame3.FrameID;
-
-                await controllerService.SignSetTextFrame(signSetTextFrame3.AsEntity());
-            }
-
-            if (extendedRequestMessage.Frame4 != null)
-            {
-                signSetMessage.Frame4Time = (byte)(extendedRequestMessage.Frame4Time * 10);
-
-                SignSetTextFrameDto signSetTextFrame4 = new SignSetTextFrameDto
-                {
-                    FrameID = GetNextId(device),
-                    Revision = 0,
-                    Font = extendedRequestMessage.Frame4.Font,
-                    Colour = extendedRequestMessage.Frame4.Colour,
-                    Conspicuity = extendedRequestMessage.Frame4.Conspicuity,
-                    Text = extendedRequestMessage.Frame4.Text
-                };
-
-                signSetMessage.Frame4ID = signSetTextFrame4.FrameID;
-
-                await controllerService.SignSetTextFrame(signSetTextFrame4.AsEntity());
-            }
-
-            if (extendedRequestMessage.Frame5 != null)
-            {
-                signSetMessage.Frame5Time = (byte)(extendedRequestMessage.Frame5Time * 10);
-
-                SignSetTextFrameDto signSetTextFrame5 = new SignSetTextFrameDto
-                {
-                    FrameID = GetNextId(device),
-                    Revision = 0,
-                    Font = extendedRequestMessage.Frame5.Font,
-                    Colour = extendedRequestMessage.Frame5.Colour,
-                    Conspicuity = extendedRequestMessage.Frame5.Conspicuity,
-                    Text = extendedRequestMessage.Frame5.Text
-                };
-
-                signSetMessage.Frame5ID = signSetTextFrame5.FrameID;
-
-                await controllerService.SignSetTextFrame(signSetTextFrame5.AsEntity());
-            }
-
-            if (extendedRequestMessage.Frame6 != null)
-            {
-                signSetMessage.Frame6Time = (byte)(extendedRequestMessage.Frame6Time * 10);
-
-                SignSetTextFrameDto signSetTextFrame6 = new SignSetTextFrameDto
-                {
-                    FrameID = GetNextId(device),
-                    Revision = 0,
-                    Font = extendedRequestMessage.Frame6.Font,
-                    Colour = extendedRequestMessage.Frame6.Colour,
-                    Conspicuity = extendedRequestMessage.Frame6.Conspicuity,
-                    Text = extendedRequestMessage.Frame6.Text
-                };
-
-                signSetMessage.Frame6ID = signSetTextFrame6.FrameID;
-
-                await controllerService.SignSetTextFrame(signSetTextFrame6.AsEntity());
-            }
-
-            await controllerService.SignSetMessage(signSetMessage.AsEntity());
-
-            await controllerService.SignDisplayMessage(new SignDisplayMessage
-            {
-                GroupID = 1,
-                MessageID = signSetMessage.MessageID
-            });
-
-
-        }
-        catch (TimeoutException ex)
-        {
-            _logger.LogWarning(ex, "Sign Status Request timed out for device {Device}", device);
-            return StatusCode(StatusCodes.Status408RequestTimeout, "Sign Status Request timed out.");
-        }
-        catch (SignRequestRejectedException ex)
-        {
-            _logger.LogError($"Request rejected: {ex.RejectReply.ApplicationErrorCode}");
-            return StatusCode(StatusCodes.Status400BadRequest, ex.RejectReply.AsDto());
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error requesting status for device {Device}", device);
-            return StatusCode(StatusCodes.Status500InternalServerError, "Error requesting status.");
-        }
-        // Get the elapsed time as a TimeSpan value
-        TimeSpan ts = stopwatch.Elapsed;
-
-        // Log the elapsed time
-        _logger.LogDebug("Elapsed Time: {Hours:00}:{Minutes:00}:{Seconds:00}.{Milliseconds:00}",
-            ts.Hours, ts.Minutes, ts.Seconds, ts.Milliseconds / 10);
-
-        return Ok();
-
     }
 }

--- a/src/TSISP003.Api/Program.cs
+++ b/src/TSISP003.Api/Program.cs
@@ -1,3 +1,5 @@
+using TSISP003.Application.Interfaces;
+using TSISP003.Application.Services;
 using TSISP003.Infrastructure;
 using TSISP003.ServiceDefaults;
 
@@ -13,6 +15,9 @@ internal class Program
 
         builder.Services.AddControllers();
         builder.Services.AddInfrastructure(builder.Configuration);
+
+        // Extended (non-protocol) management operations. Singleton: owns rolling per-device IDs.
+        builder.Services.AddSingleton<IExtendedSignService, ExtendedSignService>();
         builder.Services.AddEndpointsApiExplorer();
         builder.Services.AddSwaggerGen();
 

--- a/src/TSISP003.Api/appsettings.json
+++ b/src/TSISP003.Api/appsettings.json
@@ -2,7 +2,8 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "TSISP003.Infrastructure.Services.SignControllerService": "Debug"
     }
   },
   "AllowedHosts": "*"

--- a/src/TSISP003.AppHost/Program.cs
+++ b/src/TSISP003.AppHost/Program.cs
@@ -1,5 +1,21 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
-var api = builder.AddProject<Projects.TSISP003_Api>("tsisp003-api");
+// TSI-SP-003 sign controller simulator: a single device with one text sign,
+// listening for raw TCP on a fixed port so the API can connect to it.
+var simulator = builder.AddProject<Projects.TSISP003_Simulator>("simulator")
+    .WithEnvironment("Simulator__Port", "5050")
+    .WithEnvironment("Simulator__Address", "01")
+    .WithEnvironment("Simulator__Seed", "18")
+    .WithEndpoint(name: "tcp", scheme: "tcp", port: 5050, targetPort: 5050, isProxied: false);
+
+// API talks to the simulator as a configured device. The simulator accepts any
+// password, so the seed/password offsets only need to be well-formed hex.
+builder.AddProject<Projects.TSISP003_Api>("tsisp003-api")
+    .WaitFor(simulator)
+    .WithEnvironment("SignControllerServices__Devices__sim__IpAddress", "127.0.0.1")
+    .WithEnvironment("SignControllerServices__Devices__sim__Port", "5050")
+    .WithEnvironment("SignControllerServices__Devices__sim__Address", "01")
+    .WithEnvironment("SignControllerServices__Devices__sim__SeedOffset", "00")
+    .WithEnvironment("SignControllerServices__Devices__sim__PasswordOffset", "00");
 
 builder.Build().Run();

--- a/src/TSISP003.AppHost/Program.cs
+++ b/src/TSISP003.AppHost/Program.cs
@@ -1,21 +1,32 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
-// TSI-SP-003 sign controller simulator: a single device with one text sign,
-// listening for raw TCP on a fixed port so the API can connect to it.
+// TSI-SP-003 sign controller simulator: a single process hosting three sign
+// controllers, each on its own raw-TCP port (configured in the simulator's
+// appsettings.json), each a group of three text signs. Ports avoid 5000 because
+// macOS reserves it for the AirPlay Receiver.
 var simulator = builder.AddProject<Projects.TSISP003_Simulator>("simulator")
-    .WithEnvironment("Simulator__Port", "5050")
-    .WithEnvironment("Simulator__Address", "01")
-    .WithEnvironment("Simulator__Seed", "18")
-    .WithEndpoint(name: "tcp", scheme: "tcp", port: 5050, targetPort: 5050, isProxied: false);
+    .WithEndpoint(name: "tcp-1", scheme: "tcp", port: 5050, targetPort: 5050, isProxied: false)
+    .WithEndpoint(name: "tcp-2", scheme: "tcp", port: 5051, targetPort: 5051, isProxied: false)
+    .WithEndpoint(name: "tcp-3", scheme: "tcp", port: 5052, targetPort: 5052, isProxied: false);
 
-// API talks to the simulator as a configured device. The simulator accepts any
-// password, so the seed/password offsets only need to be well-formed hex.
+// API connects to each simulated controller as a separate device. The simulator
+// accepts any password, so seed/password offsets only need to be well-formed hex.
 builder.AddProject<Projects.TSISP003_Api>("tsisp003-api")
     .WaitFor(simulator)
-    .WithEnvironment("SignControllerServices__Devices__sim__IpAddress", "127.0.0.1")
-    .WithEnvironment("SignControllerServices__Devices__sim__Port", "5050")
-    .WithEnvironment("SignControllerServices__Devices__sim__Address", "01")
-    .WithEnvironment("SignControllerServices__Devices__sim__SeedOffset", "00")
-    .WithEnvironment("SignControllerServices__Devices__sim__PasswordOffset", "00");
+    .WithEnvironment("SignControllerServices__Devices__sim-1__IpAddress", "127.0.0.1")
+    .WithEnvironment("SignControllerServices__Devices__sim-1__Port", "5050")
+    .WithEnvironment("SignControllerServices__Devices__sim-1__Address", "01")
+    .WithEnvironment("SignControllerServices__Devices__sim-1__SeedOffset", "00")
+    .WithEnvironment("SignControllerServices__Devices__sim-1__PasswordOffset", "00")
+    .WithEnvironment("SignControllerServices__Devices__sim-2__IpAddress", "127.0.0.1")
+    .WithEnvironment("SignControllerServices__Devices__sim-2__Port", "5051")
+    .WithEnvironment("SignControllerServices__Devices__sim-2__Address", "02")
+    .WithEnvironment("SignControllerServices__Devices__sim-2__SeedOffset", "00")
+    .WithEnvironment("SignControllerServices__Devices__sim-2__PasswordOffset", "00")
+    .WithEnvironment("SignControllerServices__Devices__sim-3__IpAddress", "127.0.0.1")
+    .WithEnvironment("SignControllerServices__Devices__sim-3__Port", "5052")
+    .WithEnvironment("SignControllerServices__Devices__sim-3__Address", "03")
+    .WithEnvironment("SignControllerServices__Devices__sim-3__SeedOffset", "00")
+    .WithEnvironment("SignControllerServices__Devices__sim-3__PasswordOffset", "00");
 
 builder.Build().Run();

--- a/src/TSISP003.AppHost/TSISP003.AppHost.csproj
+++ b/src/TSISP003.AppHost/TSISP003.AppHost.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\TSISP003.Api\TSISP003.Api.csproj" />
+    <ProjectReference Include="..\TSISP003.Simulator\TSISP003.Simulator.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/TSISP003.Application/DTOs/DeviceDtos.cs
+++ b/src/TSISP003.Application/DTOs/DeviceDtos.cs
@@ -1,0 +1,10 @@
+namespace TSISP003.Application.DTOs;
+
+/// <summary>A configured sign controller device, as exposed by the device-listing endpoint.</summary>
+public class DeviceInfoDto
+{
+    public required string Name { get; set; }
+    public required string Address { get; set; }
+    public required string IpAddress { get; set; }
+    public int Port { get; set; }
+}

--- a/src/TSISP003.Application/DTOs/ExtendedStatusDtos.cs
+++ b/src/TSISP003.Application/DTOs/ExtendedStatusDtos.cs
@@ -1,0 +1,68 @@
+namespace TSISP003.Application.DTOs;
+
+/// <summary>
+/// Sign status enriched with the resolved content of each sign's active message/frame,
+/// fetched live from the controller via Request-Stored. Returned by GET extended/status.
+/// </summary>
+public class ExtendedStatusReplyDto
+{
+    public bool OnlineStatus { get; set; }
+    public byte ApplicationErrorCode { get; set; }
+    public DateTime DateTime { get; set; }
+    public ushort ControllerChecksum { get; set; }
+    public byte ControllerErrorCode { get; set; }
+    public required string ControllerError { get; set; }
+    public byte NumberOfSigns { get; set; }
+    public Dictionary<byte, ExtendedSignStatusContentDto> Signs { get; set; } = [];
+}
+
+public class ExtendedSignStatusContentDto
+{
+    public byte SignID { get; set; }
+    public byte SignErrorCode { get; set; }
+    public required string SignError { get; set; }
+    public bool SignEnabled { get; set; }
+    public byte FrameID { get; set; }
+    public byte FrameRevision { get; set; }
+    public byte MessageID { get; set; }
+    public byte MessageRevision { get; set; }
+    public byte PlanID { get; set; }
+    public byte PlanRevision { get; set; }
+
+    /// <summary>Resolved content of the active message (null if the sign has no active message or it could not be fetched).</summary>
+    public ExtendedMessageContentDto? ActiveMessage { get; set; }
+
+    /// <summary>Resolved content of a directly-displayed active frame (null if the sign is showing a message or no frame).</summary>
+    public ExtendedFrameContentDto? ActiveFrame { get; set; }
+}
+
+public class ExtendedMessageContentDto
+{
+    public byte MessageID { get; set; }
+    public byte Revision { get; set; }
+    public byte TransitionTimeBetweenFrames { get; set; }
+    public List<ExtendedMessageFrameDto> Frames { get; set; } = [];
+}
+
+public class ExtendedMessageFrameDto
+{
+    public byte FrameID { get; set; }
+    /// <summary>Per-frame display time as stored in the controller (protocol units).</summary>
+    public byte Time { get; set; }
+    public byte Font { get; set; }
+    public byte Colour { get; set; }
+    public byte Conspicuity { get; set; }
+    /// <summary>Decoded frame text, or null if the frame is not a text frame or could not be fetched.</summary>
+    public string? Text { get; set; }
+}
+
+public class ExtendedFrameContentDto
+{
+    public byte FrameID { get; set; }
+    public byte Revision { get; set; }
+    public byte Font { get; set; }
+    public byte Colour { get; set; }
+    public byte Conspicuity { get; set; }
+    /// <summary>Decoded frame text, or null if the frame is not a text frame or could not be fetched.</summary>
+    public string? Text { get; set; }
+}

--- a/src/TSISP003.Application/Interfaces/IExtendedSignService.cs
+++ b/src/TSISP003.Application/Interfaces/IExtendedSignService.cs
@@ -1,0 +1,24 @@
+using TSISP003.Application.DTOs;
+
+namespace TSISP003.Application.Interfaces;
+
+/// <summary>
+/// "Extended" operations layered on top of the TSI-SP-003 protocol — management
+/// conveniences that are NOT part of the protocol itself, but orchestrate several
+/// protocol operations together.
+/// </summary>
+public interface IExtendedSignService
+{
+    /// <summary>
+    /// Builds text frames from the request under rolling IDs, assembles a message from them,
+    /// and displays that message on group 1 of the device.
+    /// </summary>
+    Task BuildAndDisplayMessageAsync(string device, ExtendedRequestMessageDto request);
+
+    /// <summary>
+    /// Returns the device's sign status enriched with the resolved content (frames and decoded
+    /// text) of each sign's active message/frame, fetched live from the controller via
+    /// Request-Stored. Returns null if no status is available.
+    /// </summary>
+    Task<ExtendedStatusReplyDto?> GetExtendedStatusAsync(string device);
+}

--- a/src/TSISP003.Application/Services/ExtendedSignService.cs
+++ b/src/TSISP003.Application/Services/ExtendedSignService.cs
@@ -1,0 +1,224 @@
+using System.Collections.Concurrent;
+using System.Text;
+using TSISP003.Application.DTOs;
+using TSISP003.Application.Interfaces;
+using TSISP003.Application.Mapping;
+using TSISP003.Domain.Entities;
+using TSISP003.Domain.Enums;
+
+namespace TSISP003.Application.Services;
+
+/// <summary>
+/// Orchestrates "extended" (non-protocol) management operations over the protocol
+/// primitives exposed by <see cref="ISignControllerService"/>. Registered as a singleton
+/// because it owns rolling per-device frame/message IDs that persist across requests.
+/// </summary>
+public class ExtendedSignService(ISignControllerServiceFactory factory) : IExtendedSignService
+{
+    // Rolling frame/message IDs per device, cycling 120..254 and shared across requests.
+    private readonly ConcurrentDictionary<string, int> _deviceIds = new();
+    private const byte MinId = 120;
+    private const byte MaxId = 254;
+
+    private byte GetNextId(string device)
+        => (byte)_deviceIds.AddOrUpdate(device, MinId, (_, current) => current >= MaxId ? MinId : current + 1);
+
+    public async Task BuildAndDisplayMessageAsync(string device, ExtendedRequestMessageDto request)
+    {
+        var controller = factory.GetSignControllerService(device);
+
+        var message = new SignSetMessageDto { MessageID = GetNextId(device) };
+
+        async Task<byte> StoreFrameAsync(ExtendedTextFrameDto frame)
+        {
+            var textFrame = new SignSetTextFrameDto
+            {
+                FrameID = GetNextId(device),
+                Revision = 0,
+                Font = frame.Font,
+                Colour = frame.Colour,
+                Conspicuity = frame.Conspicuity,
+                Text = frame.Text
+            };
+            await controller.SignSetTextFrame(textFrame.AsEntity());
+            return textFrame.FrameID;
+        }
+
+        if (request.Frame1 is not null) { message.Frame1ID = await StoreFrameAsync(request.Frame1); message.Frame1Time = (byte)(request.Frame1Time * 10); }
+        if (request.Frame2 is not null) { message.Frame2ID = await StoreFrameAsync(request.Frame2); message.Frame2Time = (byte)(request.Frame2Time * 10); }
+        if (request.Frame3 is not null) { message.Frame3ID = await StoreFrameAsync(request.Frame3); message.Frame3Time = (byte)(request.Frame3Time * 10); }
+        if (request.Frame4 is not null) { message.Frame4ID = await StoreFrameAsync(request.Frame4); message.Frame4Time = (byte)(request.Frame4Time * 10); }
+        if (request.Frame5 is not null) { message.Frame5ID = await StoreFrameAsync(request.Frame5); message.Frame5Time = (byte)(request.Frame5Time * 10); }
+        if (request.Frame6 is not null) { message.Frame6ID = await StoreFrameAsync(request.Frame6); message.Frame6Time = (byte)(request.Frame6Time * 10); }
+
+        await controller.SignSetMessage(message.AsEntity());
+
+        await controller.SignDisplayMessage(new SignDisplayMessage
+        {
+            GroupID = 1,
+            MessageID = message.MessageID
+        });
+    }
+
+    public async Task<ExtendedStatusReplyDto?> GetExtendedStatusAsync(string device)
+    {
+        var controller = factory.GetSignControllerService(device);
+
+        var status = await controller.GetStatus();
+        if (status is null)
+            return null;
+
+        var baseDto = status.AsDto();
+
+        // Resolve each distinct message/frame only once per request.
+        var messageCache = new Dictionary<byte, ExtendedMessageContentDto?>();
+        var frameCache = new Dictionary<byte, ExtendedFrameContentDto?>();
+
+        var result = new ExtendedStatusReplyDto
+        {
+            OnlineStatus = baseDto.OnlineStatus,
+            ApplicationErrorCode = baseDto.ApplicationErrorCode,
+            DateTime = baseDto.dateTime,
+            ControllerChecksum = baseDto.ControllerChecksum,
+            ControllerErrorCode = baseDto.ControllerErrorCode,
+            ControllerError = baseDto.ControllerError,
+            NumberOfSigns = baseDto.NumberOfSigns
+        };
+
+        foreach (var (signId, sign) in baseDto.Signs)
+        {
+            var enriched = new ExtendedSignStatusContentDto
+            {
+                SignID = sign.SignID,
+                SignErrorCode = sign.SignErrorCode,
+                SignError = sign.SignError,
+                SignEnabled = sign.SignEnabled,
+                FrameID = sign.FrameID,
+                FrameRevision = sign.FrameRevision,
+                MessageID = sign.MessageID,
+                MessageRevision = sign.MessageRevision,
+                PlanID = sign.PlanID,
+                PlanRevision = sign.PlanRevision
+            };
+
+            if (sign.MessageID != 0)
+                enriched.ActiveMessage = await ResolveMessageAsync(controller, sign.MessageID, messageCache, frameCache);
+
+            if (sign.FrameID != 0)
+                enriched.ActiveFrame = await ResolveFrameAsync(controller, sign.FrameID, frameCache);
+
+            result.Signs[signId] = enriched;
+        }
+
+        return result;
+    }
+
+    private async Task<ExtendedMessageContentDto?> ResolveMessageAsync(
+        ISignControllerService controller, byte messageId,
+        Dictionary<byte, ExtendedMessageContentDto?> messageCache,
+        Dictionary<byte, ExtendedFrameContentDto?> frameCache)
+    {
+        if (messageCache.TryGetValue(messageId, out var cached))
+            return cached;
+
+        ExtendedMessageContentDto? content = null;
+        try
+        {
+            if (await controller.SignRequestStoredFrameMessagePlan(RequestType.Message, messageId) is SignSetMessage msg)
+            {
+                content = new ExtendedMessageContentDto
+                {
+                    MessageID = msg.MessageID,
+                    Revision = msg.Revision,
+                    TransitionTimeBetweenFrames = msg.TransitionTimeBetweenFrames
+                };
+
+                foreach (var (frameId, time) in EnumerateFrames(msg))
+                {
+                    if (frameId == 0)
+                        continue;
+
+                    var frame = await ResolveFrameAsync(controller, frameId, frameCache);
+                    content.Frames.Add(new ExtendedMessageFrameDto
+                    {
+                        FrameID = frameId,
+                        Time = time,
+                        Font = frame?.Font ?? 0,
+                        Colour = frame?.Colour ?? 0,
+                        Conspicuity = frame?.Conspicuity ?? 0,
+                        Text = frame?.Text
+                    });
+                }
+            }
+        }
+        catch
+        {
+            // Not stored / timed out / rejected — leave content null.
+        }
+
+        messageCache[messageId] = content;
+        return content;
+    }
+
+    private async Task<ExtendedFrameContentDto?> ResolveFrameAsync(
+        ISignControllerService controller, byte frameId,
+        Dictionary<byte, ExtendedFrameContentDto?> frameCache)
+    {
+        if (frameCache.TryGetValue(frameId, out var cached))
+            return cached;
+
+        ExtendedFrameContentDto? content = null;
+        try
+        {
+            // Only text frames carry readable text; graphics/hi-res frames resolve to null text.
+            if (await controller.SignRequestStoredFrameMessagePlan(RequestType.Frame, frameId) is SignSetTextFrame textFrame)
+            {
+                content = new ExtendedFrameContentDto
+                {
+                    FrameID = textFrame.FrameID,
+                    Revision = textFrame.Revision,
+                    Font = textFrame.Font,
+                    Colour = textFrame.Colour,
+                    Conspicuity = textFrame.Conspicuity,
+                    Text = DecodeHexText(textFrame.Text)
+                };
+            }
+        }
+        catch
+        {
+            // Not stored / timed out / rejected — leave content null.
+        }
+
+        frameCache[frameId] = content;
+        return content;
+    }
+
+    private static IEnumerable<(byte FrameId, byte Time)> EnumerateFrames(SignSetMessage m)
+    {
+        yield return (m.Frame1ID, m.Frame1Time);
+        yield return (m.Frame2ID, m.Frame2Time);
+        yield return (m.Frame3ID, m.Frame3Time);
+        yield return (m.Frame4ID, m.Frame4Time);
+        yield return (m.Frame5ID, m.Frame5Time);
+        yield return (m.Frame6ID, m.Frame6Time);
+    }
+
+    /// <summary>Decodes a hex-encoded ASCII string (e.g. "48454C4C4F" → "HELLO"); returns the input unchanged if it is not valid hex.</summary>
+    private static string? DecodeHexText(string? hex)
+    {
+        if (string.IsNullOrEmpty(hex) || hex.Length % 2 != 0)
+            return hex;
+
+        try
+        {
+            var bytes = new byte[hex.Length / 2];
+            for (int i = 0; i < bytes.Length; i++)
+                bytes[i] = Convert.ToByte(hex.Substring(i * 2, 2), 16);
+            return Encoding.ASCII.GetString(bytes);
+        }
+        catch
+        {
+            return hex;
+        }
+    }
+}

--- a/src/TSISP003.Infrastructure/Services/SignControllerService.cs
+++ b/src/TSISP003.Infrastructure/Services/SignControllerService.cs
@@ -16,9 +16,13 @@ namespace TSISP003.Infrastructure.Services;
 public class SignControllerService(
     ITcpClient tcpClient,
     SignControllerConnectionOptions deviceSettings,
+    string deviceName,
     ILogger<SignControllerService> logger) : ISignControllerService, IHostedService, IDisposable
 {
     private readonly ILogger<SignControllerService> _logger = logger;
+
+    /// <summary>Friendly identifier for this controller in transaction logs (device name, or address if unnamed).</summary>
+    private readonly string _controller = string.IsNullOrWhiteSpace(deviceName) ? deviceSettings.Address : deviceName;
     private TaskCompletionSource<List<FaultLogEntry>>? _faultLogReplyTaskCompletion;
     private TaskCompletionSource<SignStatusReply>? _signStatusReplyTaskCompletion;
     private TaskCompletionSource<SignSetTextFrame>? _signSetTextFrameTaskCompletion;
@@ -407,11 +411,15 @@ public class SignControllerService(
             // the slave has received from us. This confirms our last packet was received.
             int slaveNR = int.Parse(packet[1..3], System.Globalization.NumberStyles.HexNumber);
 
+            _logger.LogDebug("[SignController {Controller}] RX Ack (N(R)={NR})", _controller, packet[1..3]);
+
             // Increment our send sequence number for the next packet we send
             NS = IncrementSequenceNumber(NS);
         }
         else if (packet[0] == ProtocolConstants.NAK)
         {
+            _logger.LogDebug("[SignController {Controller}] RX Nak (N(R)={NR})", _controller, packet[1..3]);
+
             // NAK received - slave rejected our packet (sequence error or corrupted data)
             // We should retransmit the last packet (not incrementing NS)
             // TODO: Implement retransmission logic
@@ -437,6 +445,9 @@ public class SignControllerService(
 
         string applicationData = packet[8..^5];
         int miCode = Convert.ToInt32(packet[8..10], 16);
+
+        _logger.LogDebug("[SignController {Controller}] RX {Operation} (N(S)={NS}, N(R)={NR})",
+            _controller, MiName(miCode), packet[1..3], packet[3..5]);
 
         if (miCode == ProtocolConstants.MI_SIGN_STATUS_REPLY)
             await ProcessSignStatusReply(applicationData);
@@ -500,6 +511,68 @@ public class SignControllerService(
     }
 
     /// <summary>
+    /// Send a built protocol packet, logging the outgoing transaction at Debug with the
+    /// controller identity, the operation name, and the sequence numbers.
+    /// Packet layout: SOH NS(2) NR(2) ADDR(2) STX MI(2) ...
+    /// </summary>
+    private async Task SendPacketAsync(string message)
+    {
+        if (message.Length >= 10)
+        {
+            string op = MiName(Convert.ToInt32(message[8..10], 16));
+            _logger.LogDebug("[SignController {Controller}] TX {Operation} (N(S)={NS}, N(R)={NR})",
+                _controller, op, message[1..3], message[3..5]);
+        }
+        await _tcpClient.SendAsync(message);
+    }
+
+    /// <summary>Map a Message Information (MI) code to a human-readable operation name for logging.</summary>
+    private static string MiName(int mi) => mi switch
+    {
+        ProtocolConstants.MI_REJECT_MESSAGE => "Reject",
+        ProtocolConstants.MI_ACK_MESSAGE => "Ack",
+        ProtocolConstants.MI_START_SESSION => "StartSession",
+        ProtocolConstants.MI_PASSWORD_SEED => "PasswordSeed",
+        ProtocolConstants.MI_PASSWORD => "Password",
+        ProtocolConstants.MI_HEARTBEAT_POLL => "Heartbeat",
+        ProtocolConstants.MI_SIGN_STATUS_REPLY => "SignStatusReply",
+        ProtocolConstants.MI_END_SESSION => "EndSession",
+        ProtocolConstants.MI_SYSTEM_RESET => "SystemReset",
+        ProtocolConstants.MI_UPDATE_TIME => "UpdateTime",
+        ProtocolConstants.MI_SIGN_SET_TEXT_FRAME => "SignSetTextFrame",
+        ProtocolConstants.MI_SIGN_SET_GRAPHIC_FRAME => "SignSetGraphicsFrame",
+        ProtocolConstants.MI_SIGN_SET_MESSAGE => "SignSetMessage",
+        ProtocolConstants.MI_SIGN_SET_PLAN => "SignSetPlan",
+        ProtocolConstants.MI_SIGN_DISPLAY_FRAME => "SignDisplayFrame",
+        ProtocolConstants.MI_SIGN_DISPLAY_MESSAGE => "SignDisplayMessage",
+        ProtocolConstants.MI_ENABLE_PLAN => "EnablePlan",
+        ProtocolConstants.MI_DISABLE_PLAN => "DisablePlan",
+        ProtocolConstants.MI_REQUEST_ENABLED_PLANS => "RequestEnabledPlans",
+        ProtocolConstants.MI_REPORT_ENABLED_PLANS => "ReportEnabledPlans",
+        ProtocolConstants.MI_SIGN_SET_DIMMING_LEVEL => "SignSetDimmingLevel",
+        ProtocolConstants.MI_POWER_ON_OFF => "PowerOnOff",
+        ProtocolConstants.MI_DISABLE_ENABLE_DEVICE => "DisableEnableDevice",
+        ProtocolConstants.MI_SIGN_REQUEST_STORED_FRAME_MESSAGE_PLAN => "RequestStoredFrameMessagePlan",
+        ProtocolConstants.MI_RETRIEVE_FAULT_LOG => "RetrieveFaultLog",
+        ProtocolConstants.MI_FAULT_LOG_REPLY => "FaultLogReply",
+        ProtocolConstants.MI_RESET_FAULT_LOG => "ResetFaultLog",
+        ProtocolConstants.MI_SIGN_EXTENDED_STATUS_REQUEST => "SignExtendedStatusRequest",
+        ProtocolConstants.MI_SIGN_EXTENDED_STATUS_REPLY => "SignExtendedStatusReply",
+        ProtocolConstants.MI_SIGN_SET_HIGH_RESOLUTION_GRAPHICS_FRAME => "SignSetHighResolutionGraphicsFrame",
+        ProtocolConstants.MI_SIGN_CONFIGURATION_REQUEST => "SignConfigurationRequest",
+        ProtocolConstants.MI_SIGN_CONFIGURATION_REPLY => "SignConfigurationReply",
+        ProtocolConstants.MI_SIGN_DISPLAY_ATOMIC_FRAMES => "SignDisplayAtomicFrames",
+        ProtocolConstants.MI_HAR_STATUS_REPLY => "HARStatusReply",
+        ProtocolConstants.MI_HAR_SET_STRATEGY => "HARSetStrategy",
+        ProtocolConstants.MI_HAR_ACTIVATE_STRATEGY => "HARActivateStrategy",
+        ProtocolConstants.MI_HAR_SET_PLAN => "HARSetPlan",
+        ProtocolConstants.MI_HAR_REQUEST_STORED_VOICE_STRATEGY_PLAN => "HARRequestStoredVoiceStrategyPlan",
+        ProtocolConstants.MI_HAR_SET_VOICE_DATA_ACK => "HARVoiceDataAck",
+        ProtocolConstants.MI_HAR_SET_VOICE_DATA_NAK => "HARVoiceDataNak",
+        _ => $"MI(0x{mi:X2})",
+    };
+
+    /// <summary>
     /// Send a heartbeat poll
     /// </summary>
     /// <returns></returns>
@@ -517,7 +590,7 @@ public class SignControllerService(
                     + ProtocolHelper.PacketCRC(Encoding.ASCII.GetBytes(message))
                     + ProtocolConstants.ETX;
 
-        await _tcpClient.SendAsync(message);
+        await SendPacketAsync(message);
     }
 
     /// <summary>
@@ -544,7 +617,7 @@ public class SignControllerService(
                     + ProtocolHelper.PacketCRC(Encoding.ASCII.GetBytes(message))
                     + ProtocolConstants.ETX;
 
-        await _tcpClient.SendAsync(message);
+        await SendPacketAsync(message);
     }
 
     /// <summary>
@@ -567,7 +640,7 @@ public class SignControllerService(
         message = message + crc
                     + ProtocolConstants.ETX;
 
-        await _tcpClient.SendAsync(message);
+        await SendPacketAsync(message);
     }
 
     /// <summary>
@@ -594,7 +667,7 @@ public class SignControllerService(
                     + ProtocolHelper.PacketCRC(Encoding.ASCII.GetBytes(message))
                     + ProtocolConstants.ETX;
 
-        await _tcpClient.SendAsync(message);
+        await SendPacketAsync(message);
     }
 
     /// <summary>
@@ -633,7 +706,7 @@ public class SignControllerService(
                     + ProtocolHelper.PacketCRC(Encoding.ASCII.GetBytes(message))
                     + ProtocolConstants.ETX;
 
-        await _tcpClient.SendAsync(message);
+        await SendPacketAsync(message);
 
         // Wait for either the ack reply to be received or a timeout after 3 seconds.
         var delayTask = Task.Delay(TimeSpan.FromSeconds(3));
@@ -700,7 +773,7 @@ public class SignControllerService(
                     + ProtocolHelper.PacketCRC(Encoding.ASCII.GetBytes(message))
                     + ProtocolConstants.ETX;
 
-        await _tcpClient.SendAsync(message);
+        await SendPacketAsync(message);
 
         // Wait for either the reply to be received or a timeout after 3 seconds.
         var delayTask = Task.Delay(TimeSpan.FromSeconds(3));
@@ -751,7 +824,7 @@ public class SignControllerService(
                     + ProtocolHelper.PacketCRC(Encoding.ASCII.GetBytes(message))
                     + ProtocolConstants.ETX;
 
-        await _tcpClient.SendAsync(message);
+        await SendPacketAsync(message);
 
         // Wait for either the fault log reply to be received or a timeout after 3 seconds.
         var delayTask = Task.Delay(TimeSpan.FromSeconds(3));
@@ -840,7 +913,7 @@ public class SignControllerService(
                     + ProtocolHelper.PacketCRC(Encoding.ASCII.GetBytes(message))
                     + ProtocolConstants.ETX;
 
-        await _tcpClient.SendAsync(message);
+        await SendPacketAsync(message);
 
         // Wait for either the sign status reply to be received or a timeout after 3 seconds.
         var delayTask = Task.Delay(TimeSpan.FromSeconds(3));
@@ -952,7 +1025,7 @@ public class SignControllerService(
                     + ProtocolHelper.PacketCRC(Encoding.ASCII.GetBytes(message))
                     + ProtocolConstants.ETX;
 
-        await _tcpClient.SendAsync(message);
+        await SendPacketAsync(message);
 
         // Wait for either the sign status reply to be received or a timeout after 3 seconds.
         var delayTask = Task.Delay(TimeSpan.FromSeconds(3));
@@ -987,7 +1060,7 @@ public class SignControllerService(
                     + ProtocolHelper.PacketCRC(Encoding.ASCII.GetBytes(message))
                     + ProtocolConstants.ETX;
 
-        await _tcpClient.SendAsync(message);
+        await SendPacketAsync(message);
     }
 
     /// <summary>
@@ -1022,7 +1095,7 @@ public class SignControllerService(
                     + ProtocolHelper.PacketCRC(Encoding.ASCII.GetBytes(message))
                     + ProtocolConstants.ETX;
 
-        await _tcpClient.SendAsync(message);
+        await SendPacketAsync(message);
 
         // Wait for either the fault log reply to be received or a timeout after 3 seconds.
         var delayTask = Task.Delay(TimeSpan.FromSeconds(3));
@@ -1069,7 +1142,7 @@ public class SignControllerService(
                     + ProtocolHelper.PacketCRC(Encoding.ASCII.GetBytes(message))
                     + ProtocolConstants.ETX;
 
-        await _tcpClient.SendAsync(message);
+        await SendPacketAsync(message);
 
         // Wait for either the fault log reply to be received or a timeout after 3 seconds.
         var delayTask = Task.Delay(TimeSpan.FromSeconds(3));
@@ -1140,7 +1213,7 @@ public class SignControllerService(
                     + ProtocolHelper.PacketCRC(Encoding.ASCII.GetBytes(message))
                     + ProtocolConstants.ETX;
 
-        await _tcpClient.SendAsync(message);
+        await SendPacketAsync(message);
 
         // Wait for either the sign status reply to be received or a timeout after 3 seconds.
         var delayTask = Task.Delay(TimeSpan.FromSeconds(3));
@@ -1189,7 +1262,7 @@ public class SignControllerService(
                     + ProtocolHelper.PacketCRC(Encoding.ASCII.GetBytes(message))
                     + ProtocolConstants.ETX;
 
-        await _tcpClient.SendAsync(message);
+        await SendPacketAsync(message);
 
         // Wait for either the reply to be received or a timeout after 3 seconds.
         var delayTask = Task.Delay(TimeSpan.FromSeconds(3));
@@ -1233,7 +1306,7 @@ public class SignControllerService(
                     + ProtocolHelper.PacketCRC(Encoding.ASCII.GetBytes(message))
                     + ProtocolConstants.ETX;
 
-        await _tcpClient.SendAsync(message);
+        await SendPacketAsync(message);
 
         // Wait for either the reply to be received or a timeout after 3 seconds.
         var delayTask = Task.Delay(TimeSpan.FromSeconds(3));
@@ -1282,7 +1355,7 @@ public class SignControllerService(
                     + ProtocolHelper.PacketCRC(Encoding.ASCII.GetBytes(message))
                     + ProtocolConstants.ETX;
 
-        await _tcpClient.SendAsync(message);
+        await SendPacketAsync(message);
 
         // Wait for either the ack reply to be received or a timeout after 3 seconds.
         var delayTask = Task.Delay(TimeSpan.FromSeconds(3));
@@ -1331,7 +1404,7 @@ public class SignControllerService(
                     + ProtocolHelper.PacketCRC(Encoding.ASCII.GetBytes(message))
                     + ProtocolConstants.ETX;
 
-        await _tcpClient.SendAsync(message);
+        await SendPacketAsync(message);
 
         // Wait for either the ack reply to be received or a timeout after 3 seconds.
         var delayTask = Task.Delay(TimeSpan.FromSeconds(3));
@@ -1375,7 +1448,7 @@ public class SignControllerService(
                     + ProtocolHelper.PacketCRC(Encoding.ASCII.GetBytes(message))
                     + ProtocolConstants.ETX;
 
-        await _tcpClient.SendAsync(message);
+        await SendPacketAsync(message);
 
         // Wait for either the reply to be received or a timeout after 3 seconds.
         var delayTask = Task.Delay(TimeSpan.FromSeconds(3));
@@ -1432,7 +1505,7 @@ public class SignControllerService(
                     + ProtocolHelper.PacketCRC(Encoding.ASCII.GetBytes(message))
                     + ProtocolConstants.ETX;
 
-        await _tcpClient.SendAsync(message);
+        await SendPacketAsync(message);
 
         // Wait for either the ack reply to be received or a timeout after 3 seconds.
         var delayTask = Task.Delay(TimeSpan.FromSeconds(3));
@@ -1471,7 +1544,7 @@ public class SignControllerService(
                     + ProtocolHelper.PacketCRC(Encoding.ASCII.GetBytes(message))
                     + ProtocolConstants.ETX;
 
-        await _tcpClient.SendAsync(message);
+        await SendPacketAsync(message);
 
         // Wait for either the fault log reply to be received or a timeout after 3 seconds.
         var delayTask = Task.Delay(TimeSpan.FromSeconds(3));
@@ -1528,7 +1601,7 @@ public class SignControllerService(
                     + ProtocolHelper.PacketCRC(Encoding.ASCII.GetBytes(message))
                     + ProtocolConstants.ETX;
 
-        await _tcpClient.SendAsync(message);
+        await SendPacketAsync(message);
 
         // Wait for either the reply to be received or a timeout after 3 seconds.
         var delayTask = Task.Delay(TimeSpan.FromSeconds(3));
@@ -1582,7 +1655,7 @@ public class SignControllerService(
                     + ProtocolHelper.PacketCRC(Encoding.ASCII.GetBytes(message))
                     + ProtocolConstants.ETX;
 
-        await _tcpClient.SendAsync(message);
+        await SendPacketAsync(message);
 
         // Wait for either the reply to be received or a timeout after 3 seconds.
         var delayTask = Task.Delay(TimeSpan.FromSeconds(3));
@@ -1658,7 +1731,7 @@ public class SignControllerService(
                     + ProtocolHelper.PacketCRC(Encoding.ASCII.GetBytes(message))
                     + ProtocolConstants.ETX;
 
-        await _tcpClient.SendAsync(message);
+        await SendPacketAsync(message);
 
         // Wait for either the reply to be received or a timeout after 3 seconds.
         var delayTask = Task.Delay(TimeSpan.FromSeconds(3));
@@ -1699,7 +1772,7 @@ public class SignControllerService(
                     + ProtocolHelper.PacketCRC(Encoding.ASCII.GetBytes(message))
                     + ProtocolConstants.ETX;
 
-        await _tcpClient.SendAsync(message);
+        await SendPacketAsync(message);
 
         // Wait for either the fault log reply to be received or a timeout after 3 seconds.
         var delayTask = Task.Delay(TimeSpan.FromSeconds(3));
@@ -1737,7 +1810,7 @@ public class SignControllerService(
                     + ProtocolHelper.PacketCRC(Encoding.ASCII.GetBytes(message))
                     + ProtocolConstants.ETX;
 
-        await _tcpClient.SendAsync(message);
+        await SendPacketAsync(message);
 
         // Wait for either the reply to be received or a timeout after 3 seconds.
         var delayTask = Task.Delay(TimeSpan.FromSeconds(3));
@@ -1813,7 +1886,7 @@ public class SignControllerService(
         message += ProtocolHelper.PacketCRC(Encoding.ASCII.GetBytes(message));
         message += ProtocolConstants.ETX;
 
-        await _tcpClient.SendAsync(message);
+        await SendPacketAsync(message);
 
         // Wait for HAR Status Reply or timeout
         var delayTask = Task.Delay(TimeSpan.FromSeconds(3));
@@ -1861,7 +1934,7 @@ public class SignControllerService(
         message += ProtocolHelper.PacketCRC(Encoding.ASCII.GetBytes(message));
         message += ProtocolConstants.ETX;
 
-        await _tcpClient.SendAsync(message);
+        await SendPacketAsync(message);
 
         // Wait for ACK or timeout
         var delayTask = Task.Delay(TimeSpan.FromSeconds(3));
@@ -1922,7 +1995,7 @@ public class SignControllerService(
         message += ProtocolHelper.PacketCRC(Encoding.ASCII.GetBytes(message));
         message += ProtocolConstants.ETX;
 
-        await _tcpClient.SendAsync(message);
+        await SendPacketAsync(message);
 
         // Wait for HAR Status Reply or timeout
         var delayTask = Task.Delay(TimeSpan.FromSeconds(3));
@@ -1979,7 +2052,7 @@ public class SignControllerService(
         message += ProtocolHelper.PacketCRC(Encoding.ASCII.GetBytes(message));
         message += ProtocolConstants.ETX;
 
-        await _tcpClient.SendAsync(message);
+        await SendPacketAsync(message);
 
         // Wait for the appropriate reply or timeout
         var delayTask = Task.Delay(TimeSpan.FromSeconds(3));

--- a/src/TSISP003.Infrastructure/Services/SignControllerService.cs
+++ b/src/TSISP003.Infrastructure/Services/SignControllerService.cs
@@ -3,7 +3,7 @@ using TSISP003.Application.Interfaces;
 using System.Net.Sockets;
 using System.Text;
 using TSISP003.Infrastructure.Configuration;
-using TSISP003.Infrastructure.Protocol;
+using TSISP003.Protocol;
 using TSISP003.Domain.Entities;
 using TSISP003.Domain.Enums;
 using TSISP003.Domain.Exceptions;

--- a/src/TSISP003.Infrastructure/Services/SignControllerServiceFactory.cs
+++ b/src/TSISP003.Infrastructure/Services/SignControllerServiceFactory.cs
@@ -26,7 +26,7 @@ public class SignControllerServiceFactory : ISignControllerServiceFactory, IHost
     {
         var tcpLogger = _loggerFactory.CreateLogger<TcpClientAdapter>();
         var serviceLogger = _loggerFactory.CreateLogger<SignControllerService>();
-        return new SignControllerService(new TcpClientAdapter(deviceSettings.IpAddress, deviceSettings.Port, deviceName, tcpLogger), deviceSettings, serviceLogger);
+        return new SignControllerService(new TcpClientAdapter(deviceSettings.IpAddress, deviceSettings.Port, deviceName, tcpLogger), deviceSettings, deviceName, serviceLogger);
     }
 
     public ISignControllerService GetSignControllerService(string deviceName)

--- a/src/TSISP003.Infrastructure/TSISP003.Infrastructure.csproj
+++ b/src/TSISP003.Infrastructure/TSISP003.Infrastructure.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <ProjectReference Include="..\TSISP003.Domain\TSISP003.Domain.csproj" />
     <ProjectReference Include="..\TSISP003.Application\TSISP003.Application.csproj" />
+    <ProjectReference Include="..\TSISP003.Protocol\TSISP003.Protocol.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/TSISP003.Protocol/PacketCodec.cs
+++ b/src/TSISP003.Protocol/PacketCodec.cs
@@ -56,6 +56,7 @@ public static class PacketCodec
             int nr = Convert.ToInt32(packet[3..5], 16);
             string addr = packet[5..7];
             string appData = packet[8..^5];
+            if (appData.Length < 2) return false;
             int mi = Convert.ToInt32(appData[0..2], 16);
             kind = 'D';
             data = new DataPacket(ns, nr, addr, mi, appData);

--- a/src/TSISP003.Protocol/PacketCodec.cs
+++ b/src/TSISP003.Protocol/PacketCodec.cs
@@ -1,0 +1,75 @@
+using System.Text;
+
+namespace TSISP003.Protocol;
+
+public record DataPacket(int Ns, int Nr, string Addr, int Mi, string AppData);
+
+public static class PacketCodec
+{
+    public static string BuildData(int ns, int nr, string addr, string appDataWithMi)
+    {
+        string body = ProtocolConstants.SOH
+            + ns.ToString("X2") + nr.ToString("X2")
+            + addr
+            + ProtocolConstants.STX
+            + appDataWithMi;
+        return body
+            + ProtocolHelper.PacketCRC(Encoding.ASCII.GetBytes(body))
+            + ProtocolConstants.ETX;
+    }
+
+    public static string BuildAck(int nr, string addr) => BuildLink(ProtocolConstants.ACK, nr, addr);
+    public static string BuildNak(int nr, string addr) => BuildLink(ProtocolConstants.NAK, nr, addr);
+
+    private static string BuildLink(char control, int nr, string addr)
+    {
+        string body = control + nr.ToString("X2") + addr;
+        return body
+            + ProtocolHelper.PacketCRC(Encoding.ASCII.GetBytes(body))
+            + ProtocolConstants.ETX;
+    }
+
+    public static bool TryParse(string packet, out DataPacket data, out char kind)
+    {
+        data = new DataPacket(0, 0, string.Empty, 0, string.Empty);
+        kind = '?';
+        if (string.IsNullOrEmpty(packet) || packet[^1] != ProtocolConstants.ETX)
+            return false;
+
+        char start = packet[0];
+        if (start == ProtocolConstants.ACK || start == ProtocolConstants.NAK)
+        {
+            // control(1) + NR(2) + ADDR(2) + CRC(4) + ETX(1) = 10 chars
+            if (packet.Length < 10) return false;
+            kind = start == ProtocolConstants.ACK ? 'A' : 'N';
+            int lnr = Convert.ToInt32(packet[1..3], 16);
+            string laddr = packet[3..5];
+            data = new DataPacket(0, lnr, laddr, 0, string.Empty);
+            return true;
+        }
+
+        if (start == ProtocolConstants.SOH)
+        {
+            // SOH + NS(2)+NR(2)+ADDR(2) + STX + appdata + CRC(4) + ETX
+            if (packet.Length < 13 || packet[7] != ProtocolConstants.STX) return false;
+            int ns = Convert.ToInt32(packet[1..3], 16);
+            int nr = Convert.ToInt32(packet[3..5], 16);
+            string addr = packet[5..7];
+            string appData = packet[8..^5];
+            int mi = Convert.ToInt32(appData[0..2], 16);
+            kind = 'D';
+            data = new DataPacket(ns, nr, addr, mi, appData);
+            return true;
+        }
+
+        return false;
+    }
+
+    public static bool VerifyCrc(string packet)
+    {
+        if (string.IsNullOrEmpty(packet) || packet[^1] != ProtocolConstants.ETX) return false;
+        string body = packet[0..^5];          // everything except CRC(4) + ETX(1)
+        string crc = packet[^5..^1];
+        return ProtocolHelper.PacketCRC(Encoding.ASCII.GetBytes(body)) == crc;
+    }
+}

--- a/src/TSISP003.Protocol/ProtocolConstants.cs
+++ b/src/TSISP003.Protocol/ProtocolConstants.cs
@@ -1,4 +1,4 @@
-namespace TSISP003.Infrastructure.Protocol;
+namespace TSISP003.Protocol;
 
 public static class ProtocolConstants
 {

--- a/src/TSISP003.Protocol/ProtocolHelper.cs
+++ b/src/TSISP003.Protocol/ProtocolHelper.cs
@@ -1,7 +1,7 @@
 using System.Text;
 using Microsoft.Extensions.Logging;
 
-namespace TSISP003.Infrastructure.Protocol;
+namespace TSISP003.Protocol;
 
 public static class ProtocolHelper
 {

--- a/src/TSISP003.Protocol/TSISP003.Protocol.csproj
+++ b/src/TSISP003.Protocol/TSISP003.Protocol.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>TSISP003.Protocol</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+
+</Project>

--- a/src/TSISP003.Simulator/Configuration/SimulatorHostOptions.cs
+++ b/src/TSISP003.Simulator/Configuration/SimulatorHostOptions.cs
@@ -1,0 +1,10 @@
+namespace TSISP003.Simulator.Configuration;
+
+/// <summary>
+/// Top-level simulator configuration: the set of sign controllers to host,
+/// each on its own TCP port. Bound from the "Simulator" configuration section.
+/// </summary>
+public class SimulatorHostOptions
+{
+    public List<SimulatorOptions> Controllers { get; set; } = [];
+}

--- a/src/TSISP003.Simulator/Configuration/SimulatorOptions.cs
+++ b/src/TSISP003.Simulator/Configuration/SimulatorOptions.cs
@@ -1,11 +1,19 @@
 namespace TSISP003.Simulator.Configuration;
 
+/// <summary>
+/// Configuration for a single simulated sign controller (one TCP listener,
+/// one device with a group of <see cref="SignCount"/> text signs).
+/// </summary>
 public class SimulatorOptions
 {
+    public string Name { get; set; } = "controller";
     public string Address { get; set; } = "01";
     // 5050, not 5000: on macOS port 5000 is taken by the AirPlay Receiver.
     public int Port { get; set; } = 5050;
     public string SeedOffset { get; set; } = "00";
     public string PasswordOffset { get; set; } = "00";
     public byte Seed { get; set; } = 0x12;
+
+    /// <summary>Number of text signs in the controller's single group (SignIDs 1..N).</summary>
+    public int SignCount { get; set; } = 3;
 }

--- a/src/TSISP003.Simulator/Configuration/SimulatorOptions.cs
+++ b/src/TSISP003.Simulator/Configuration/SimulatorOptions.cs
@@ -3,7 +3,8 @@ namespace TSISP003.Simulator.Configuration;
 public class SimulatorOptions
 {
     public string Address { get; set; } = "01";
-    public int Port { get; set; } = 5000;
+    // 5050, not 5000: on macOS port 5000 is taken by the AirPlay Receiver.
+    public int Port { get; set; } = 5050;
     public string SeedOffset { get; set; } = "00";
     public string PasswordOffset { get; set; } = "00";
     public byte Seed { get; set; } = 0x12;

--- a/src/TSISP003.Simulator/Configuration/SimulatorOptions.cs
+++ b/src/TSISP003.Simulator/Configuration/SimulatorOptions.cs
@@ -1,0 +1,10 @@
+namespace TSISP003.Simulator.Configuration;
+
+public class SimulatorOptions
+{
+    public string Address { get; set; } = "01";
+    public int Port { get; set; } = 5000;
+    public string SeedOffset { get; set; } = "00";
+    public string PasswordOffset { get; set; } = "00";
+    public byte Seed { get; set; } = 0x12;
+}

--- a/src/TSISP003.Simulator/Program.cs
+++ b/src/TSISP003.Simulator/Program.cs
@@ -1,4 +1,14 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using TSISP003.Simulator.Configuration;
+using TSISP003.Simulator.Tcp;
 
-var host = Host.CreateDefaultBuilder(args).Build();
-await host.RunAsync();
+var builder = Host.CreateApplicationBuilder(args);
+
+var options = new SimulatorOptions();
+builder.Configuration.GetSection("Simulator").Bind(options);
+builder.Services.AddSingleton(options);
+builder.Services.AddHostedService<SimulatorListener>();
+
+await builder.Build().RunAsync();

--- a/src/TSISP003.Simulator/Program.cs
+++ b/src/TSISP003.Simulator/Program.cs
@@ -1,0 +1,4 @@
+using Microsoft.Extensions.Hosting;
+
+var host = Host.CreateDefaultBuilder(args).Build();
+await host.RunAsync();

--- a/src/TSISP003.Simulator/Program.cs
+++ b/src/TSISP003.Simulator/Program.cs
@@ -1,14 +1,31 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using TSISP003.Simulator.Configuration;
 using TSISP003.Simulator.Tcp;
 
-var builder = Host.CreateApplicationBuilder(args);
+// Root configuration at the binary's directory (where appsettings.json is copied)
+// rather than the current working directory, so the controller list loads no
+// matter where the process is launched from (dotnet run, Aspire, published exe).
+var builder = Host.CreateApplicationBuilder(new HostApplicationBuilderSettings
+{
+    Args = args,
+    ContentRootPath = AppContext.BaseDirectory,
+});
 
-var options = new SimulatorOptions();
-builder.Configuration.GetSection("Simulator").Bind(options);
-builder.Services.AddSingleton(options);
-builder.Services.AddHostedService<SimulatorListener>();
+// Bind the list of controllers to host. Fall back to a single default controller
+// if none are configured.
+var host = new SimulatorHostOptions();
+builder.Configuration.GetSection("Simulator").Bind(host);
+if (host.Controllers.Count == 0)
+    host.Controllers.Add(new SimulatorOptions());
+
+// One TCP listener (with its own in-memory store) per controller.
+foreach (var controller in host.Controllers)
+{
+    builder.Services.AddSingleton<IHostedService>(sp =>
+        new SimulatorListener(controller, sp.GetRequiredService<ILogger<SimulatorListener>>()));
+}
 
 await builder.Build().RunAsync();

--- a/src/TSISP003.Simulator/Protocol/SetCommandParser.cs
+++ b/src/TSISP003.Simulator/Protocol/SetCommandParser.cs
@@ -1,0 +1,141 @@
+using System.Text;
+using TSISP003.Protocol;
+using TSISP003.Simulator.Storage;
+
+namespace TSISP003.Simulator.Protocol;
+
+public static class SetCommandParser
+{
+    private static byte B(string s, int start) => Convert.ToByte(s[start..(start + 2)], 16);
+    private static ushort W(string s, int start) => Convert.ToUInt16(s[start..(start + 4)], 16);
+    private static uint D(string s, int start) => Convert.ToUInt32(s[start..(start + 8)], 16);
+
+    // ---- Text Frame (MI 0A) ----
+    public static StoredTextFrame ParseTextFrame(string a)
+    {
+        byte numChars = B(a, 12);
+        string textHex = a[14..(14 + numChars * 2)];
+        return new StoredTextFrame(B(a, 2), B(a, 4), B(a, 6), B(a, 8), B(a, 10), numChars, textHex);
+    }
+
+    public static string BuildTextFrameAppData(StoredTextFrame f)
+    {
+        string app = "0A"
+            + f.FrameId.ToString("X2") + f.Revision.ToString("X2")
+            + f.Font.ToString("X2") + f.Colour.ToString("X2")
+            + f.Conspicuity.ToString("X2") + f.NumChars.ToString("X2")
+            + f.TextHex;
+        return app + EmbeddedCrc(app);
+    }
+
+    // ---- Graphics Frame (MI 0B) ----
+    public static StoredGraphicsFrame ParseGraphicsFrame(string a)
+    {
+        ushort len = W(a, 14);
+        string data = a[18..(18 + len * 2)];
+        return new StoredGraphicsFrame(B(a, 2), B(a, 4), B(a, 6), B(a, 8), B(a, 10), B(a, 12), len, data);
+    }
+
+    public static string BuildGraphicsFrameAppData(StoredGraphicsFrame f)
+    {
+        string app = "0B"
+            + f.FrameId.ToString("X2") + f.Revision.ToString("X2")
+            + f.Rows.ToString("X2") + f.Cols.ToString("X2")
+            + f.Colour.ToString("X2") + f.Conspicuity.ToString("X2")
+            + f.Length.ToString("X4") + f.DataHex;
+        return app + EmbeddedCrc(app);
+    }
+
+    // ---- Hi-Res Frame (MI 1D) ----
+    public static StoredHiResFrame ParseHiResFrame(string a)
+    {
+        uint len = D(a, 18);
+        string data = a[26..(26 + (int)len * 2)];
+        return new StoredHiResFrame(B(a, 2), B(a, 4), W(a, 6), W(a, 10), B(a, 14), B(a, 16), len, data);
+    }
+
+    public static string BuildHiResFrameAppData(StoredHiResFrame f)
+    {
+        string app = "1D"
+            + f.FrameId.ToString("X2") + f.Revision.ToString("X2")
+            + f.Rows.ToString("X4") + f.Cols.ToString("X4")
+            + f.Colour.ToString("X2") + f.Conspicuity.ToString("X2")
+            + f.Length.ToString("X8") + f.DataHex;
+        return app + EmbeddedCrc(app);
+    }
+
+    // ---- Message (MI 0C) ----
+    public static StoredMessage ParseMessage(string a)
+    {
+        byte id = B(a, 2), rev = B(a, 4), transition = B(a, 6);
+        var frames = new List<(byte, byte)>();
+        for (int i = 0; i < 6; i++)
+        {
+            int off = 8 + i * 4;
+            if (off + 4 > a.Length) break;
+            byte fid = B(a, off), ftime = B(a, off + 2);
+            if (fid == 0) continue;            // 0 id = unused slot
+            frames.Add((fid, ftime));
+        }
+        return new StoredMessage(id, rev, transition, frames.ToArray());
+    }
+
+    public static string BuildMessageAppData(StoredMessage m)
+    {
+        var sb = new StringBuilder();
+        sb.Append("0C");
+        sb.Append(m.MessageId.ToString("X2"));
+        sb.Append(m.Revision.ToString("X2"));
+        sb.Append(m.TransitionTime.ToString("X2"));
+        for (int i = 0; i < 6; i++)
+        {
+            if (i < m.Frames.Length)
+            {
+                sb.Append(m.Frames[i].Id.ToString("X2"));
+                sb.Append(m.Frames[i].Time.ToString("X2"));
+            }
+            else sb.Append("0000");
+        }
+        return sb.ToString();
+    }
+
+    // ---- Plan (MI 0D) ----
+    public static StoredPlan ParsePlan(string a)
+    {
+        byte id = B(a, 2), rev = B(a, 4), dow = B(a, 6);
+        var entries = new List<StoredPlanEntry>();
+        for (int i = 0; i < 6; i++)
+        {
+            int off = 8 + i * 12;
+            if (off + 12 > a.Length) break;
+            byte type = B(a, off);
+            if (type == 0) break;              // terminator
+            entries.Add(new StoredPlanEntry(type, B(a, off + 2), B(a, off + 4),
+                B(a, off + 6), B(a, off + 8), B(a, off + 10)));
+        }
+        return new StoredPlan(id, rev, dow, entries.ToArray());
+    }
+
+    public static string BuildPlanAppData(StoredPlan p)
+    {
+        var sb = new StringBuilder();
+        sb.Append("0D");
+        sb.Append(p.PlanId.ToString("X2"));
+        sb.Append(p.Revision.ToString("X2"));
+        sb.Append(p.DayOfWeek.ToString("X2"));
+        foreach (var e in p.Entries)
+        {
+            sb.Append(e.Type.ToString("X2"));
+            sb.Append(e.Id.ToString("X2"));
+            sb.Append(e.StartHour.ToString("X2"));
+            sb.Append(e.StartMin.ToString("X2"));
+            sb.Append(e.StopHour.ToString("X2"));
+            sb.Append(e.StopMin.ToString("X2"));
+        }
+        if (p.Entries.Length < 6) sb.Append("00");
+        return sb.ToString();
+    }
+
+    private static string EmbeddedCrc(string appHex)
+        => ProtocolHelper.PacketCRC(Encoding.ASCII.GetBytes(ProtocolHelper.HexToAscii(appHex)));
+}

--- a/src/TSISP003.Simulator/Protocol/SimulatorReplyBuilder.cs
+++ b/src/TSISP003.Simulator/Protocol/SimulatorReplyBuilder.cs
@@ -6,7 +6,6 @@ namespace TSISP003.Simulator.Protocol;
 
 public class SimulatorReplyBuilder(SimulatorOptions options)
 {
-    private const byte SignId = 0x01;
     private const byte SignTypeText = 0x00;
     private const ushort SignWidth = 48;
     private const ushort SignHeight = 18;
@@ -32,35 +31,40 @@ public class SimulatorReplyBuilder(SimulatorOptions options)
         sb.Append(((byte)now.Second).ToString("X2"));
         sb.Append("0000");                            // controller checksum (WORD, ignored by client)
         sb.Append(0.ToString("D2"));                  // controller error code — DECIMAL
-        sb.Append(1.ToString("D2"));                  // number of signs — DECIMAL
 
-        lock (mem.Gate)
+        var signs = mem.SnapshotSigns();
+        sb.Append(signs.Count.ToString("D2"));        // number of signs — DECIMAL
+        foreach (var s in signs)
         {
-            sb.Append(SignId.ToString("X2"));
+            sb.Append(s.SignId.ToString("X2"));
             sb.Append("00");                          // sign error code
-            sb.Append(mem.SignEnabled ? "01" : "00");
-            sb.Append(mem.ActiveFrameId.ToString("X2"));
-            sb.Append(mem.ActiveFrameRevision.ToString("X2"));
-            sb.Append(mem.ActiveMessageId.ToString("X2"));
-            sb.Append(mem.ActiveMessageRevision.ToString("X2"));
-            sb.Append(mem.ActivePlanId.ToString("X2"));
-            sb.Append(mem.ActivePlanRevision.ToString("X2"));
+            sb.Append(s.Enabled ? "01" : "00");
+            sb.Append(s.FrameId.ToString("X2"));
+            sb.Append(s.FrameRevision.ToString("X2"));
+            sb.Append(s.MessageId.ToString("X2"));
+            sb.Append(s.MessageRevision.ToString("X2"));
+            sb.Append(s.PlanId.ToString("X2"));
+            sb.Append(s.PlanRevision.ToString("X2"));
         }
         return sb.ToString();
     }
 
     public string ConfigReply()
     {
+        int signCount = options.SignCount < 1 ? 1 : options.SignCount;
         var sb = new StringBuilder();
         sb.Append("22");
         sb.Append(new string('0', 20));               // 10-byte manufacturer code
         sb.Append(1.ToString("X2"));                  // number of groups
         sb.Append(1.ToString("X2"));                  // group id
-        sb.Append(1.ToString("X2"));                  // number of signs
-        sb.Append(SignId.ToString("X2"));
-        sb.Append(SignTypeText.ToString("X2"));
-        sb.Append(WordLoHi(SignWidth));
-        sb.Append(WordLoHi(SignHeight));
+        sb.Append(signCount.ToString("X2"));          // number of signs in the group
+        for (int i = 1; i <= signCount; i++)
+        {
+            sb.Append(((byte)i).ToString("X2"));      // sign id
+            sb.Append(SignTypeText.ToString("X2"));
+            sb.Append(WordLoHi(SignWidth));
+            sb.Append(WordLoHi(SignHeight));
+        }
         sb.Append("00");                              // signature length
         return sb.ToString();
     }

--- a/src/TSISP003.Simulator/Protocol/SimulatorReplyBuilder.cs
+++ b/src/TSISP003.Simulator/Protocol/SimulatorReplyBuilder.cs
@@ -1,0 +1,83 @@
+using System.Text;
+using TSISP003.Simulator.Configuration;
+using TSISP003.Simulator.Storage;
+
+namespace TSISP003.Simulator.Protocol;
+
+public class SimulatorReplyBuilder(SimulatorOptions options)
+{
+    private const byte SignId = 0x01;
+    private const byte SignTypeText = 0x00;
+    private const ushort SignWidth = 48;
+    private const ushort SignHeight = 18;
+
+    public string Ack() => "01";
+
+    public string PasswordSeed() => "03" + options.Seed.ToString("X2");
+
+    public string Reject(int rejectedMi, byte appErrorCode)
+        => "00" + rejectedMi.ToString("X2") + appErrorCode.ToString("X2");
+
+    public string StatusReply(SimulatorMemory mem, DateTime now)
+    {
+        var sb = new StringBuilder();
+        sb.Append("06");                              // MI
+        sb.Append("01");                              // online
+        sb.Append("00");                              // application error code
+        sb.Append(((byte)now.Day).ToString("X2"));
+        sb.Append(((byte)now.Month).ToString("X2"));
+        sb.Append(((ushort)now.Year).ToString("X4")); // year as big-endian word
+        sb.Append(((byte)now.Hour).ToString("X2"));
+        sb.Append(((byte)now.Minute).ToString("X2"));
+        sb.Append(((byte)now.Second).ToString("X2"));
+        sb.Append("0000");                            // controller checksum (WORD, ignored by client)
+        sb.Append(0.ToString("D2"));                  // controller error code — DECIMAL
+        sb.Append(1.ToString("D2"));                  // number of signs — DECIMAL
+
+        lock (mem.Gate)
+        {
+            sb.Append(SignId.ToString("X2"));
+            sb.Append("00");                          // sign error code
+            sb.Append(mem.SignEnabled ? "01" : "00");
+            sb.Append(mem.ActiveFrameId.ToString("X2"));
+            sb.Append(mem.ActiveFrameRevision.ToString("X2"));
+            sb.Append(mem.ActiveMessageId.ToString("X2"));
+            sb.Append(mem.ActiveMessageRevision.ToString("X2"));
+            sb.Append(mem.ActivePlanId.ToString("X2"));
+            sb.Append(mem.ActivePlanRevision.ToString("X2"));
+        }
+        return sb.ToString();
+    }
+
+    public string ConfigReply()
+    {
+        var sb = new StringBuilder();
+        sb.Append("22");
+        sb.Append(new string('0', 20));               // 10-byte manufacturer code
+        sb.Append(1.ToString("X2"));                  // number of groups
+        sb.Append(1.ToString("X2"));                  // group id
+        sb.Append(1.ToString("X2"));                  // number of signs
+        sb.Append(SignId.ToString("X2"));
+        sb.Append(SignTypeText.ToString("X2"));
+        sb.Append(WordLoHi(SignWidth));
+        sb.Append(WordLoHi(SignHeight));
+        sb.Append("00");                              // signature length
+        return sb.ToString();
+    }
+
+    public string ReportEnabledPlans((byte group, byte plan)[] enabled)
+    {
+        var sb = new StringBuilder();
+        sb.Append("13");
+        sb.Append(((byte)enabled.Length).ToString("X2"));
+        foreach (var (group, plan) in enabled)
+        {
+            sb.Append(group.ToString("X2"));
+            sb.Append(plan.ToString("X2"));
+        }
+        return sb.ToString();
+    }
+
+    private static string WordLoHi(ushort value)
+        => ((byte)(value & 0xFF)).ToString("X2") + ((byte)(value >> 8)).ToString("X2");
+}

--- a/src/TSISP003.Simulator/Session/SimulatorSession.cs
+++ b/src/TSISP003.Simulator/Session/SimulatorSession.cs
@@ -11,7 +11,7 @@ public class SimulatorSession(
     SimulatorOptions options,
     Func<DateTime> clock)
 {
-    private enum State { Idle, SeedSent, Online }
+    public enum State { Idle, SeedSent, Online }
 
     private const byte UnsupportedErrorCode = 0x03;
     private const byte NotFoundErrorCode = 0x04;
@@ -22,6 +22,7 @@ public class SimulatorSession(
     private const int RequestPlan = 3;
 
     private State _state = State.Idle;
+    public State CurrentState => _state;
     private int _ns;
     private int _nr;
     private string _buffer = string.Empty;
@@ -124,7 +125,9 @@ public class SimulatorSession(
                 {
                     int lastFrameOff = 6 + (numSigns - 1) * 4 + 2;
                     byte frameId = Convert.ToByte(a[lastFrameOff..(lastFrameOff + 2)], 16);
-                    byte rev = mem.GetTextFrame(frameId)?.Revision ?? (byte)0;
+                    byte rev = mem.GetTextFrame(frameId)?.Revision
+                               ?? mem.GetGraphicsFrame(frameId)?.Revision
+                               ?? mem.GetHiResFrame(frameId)?.Revision ?? (byte)0;
                     mem.SetActiveFrame(frameId, rev);
                 }
                 return replies.StatusReply(mem, clock());

--- a/src/TSISP003.Simulator/Session/SimulatorSession.cs
+++ b/src/TSISP003.Simulator/Session/SimulatorSession.cs
@@ -1,0 +1,189 @@
+using TSISP003.Protocol;
+using TSISP003.Simulator.Configuration;
+using TSISP003.Simulator.Protocol;
+using TSISP003.Simulator.Storage;
+
+namespace TSISP003.Simulator.Session;
+
+public class SimulatorSession(
+    SimulatorMemory mem,
+    SimulatorReplyBuilder replies,
+    SimulatorOptions options,
+    Func<DateTime> clock)
+{
+    private enum State { Idle, SeedSent, Online }
+
+    private const byte UnsupportedErrorCode = 0x03;
+    private const byte NotFoundErrorCode = 0x04;
+
+    // RequestType values per Domain/Enums/RequestType.cs (Frame=1, Message=2, Plan=3).
+    private const int RequestFrame = 1;
+    private const int RequestMessage = 2;
+    private const int RequestPlan = 3;
+
+    private State _state = State.Idle;
+    private int _ns;
+    private int _nr;
+    private string _buffer = string.Empty;
+    private readonly HashSet<(byte group, byte plan)> _enabledPlans = new();
+
+    public IReadOnlyList<string> Handle(string incoming)
+    {
+        var output = new List<string>();
+        _buffer += incoming;
+        var chunks = ProtocolHelper.GetChunks(_buffer, out string remaining);
+        _buffer = remaining;
+
+        foreach (var packet in chunks)
+        {
+            if (!PacketCodec.TryParse(packet, out var data, out char kind) || kind != 'D')
+                continue; // ignore link ACK/NAK and garbage from master
+
+            // Verify CRC before processing. Bad CRC → NAK with current N(R), no dispatch.
+            if (!PacketCodec.VerifyCrc(packet))
+            {
+                output.Add(PacketCodec.BuildNak(_nr, options.Address));
+                continue;
+            }
+
+            // Link-acknowledge the received data packet.
+            _nr = Increment(data.Ns);
+            output.Add(PacketCodec.BuildAck(_nr, options.Address));
+
+            string? reply = Dispatch(data);
+            if (reply is not null)
+            {
+                output.Add(PacketCodec.BuildData(_ns, _nr, options.Address, reply));
+                _ns = Increment(_ns);
+            }
+        }
+        return output;
+    }
+
+    private string? Dispatch(DataPacket data)
+    {
+        string a = data.AppData;
+        switch (data.Mi)
+        {
+            case ProtocolConstants.MI_START_SESSION:
+                _state = State.SeedSent;
+                return replies.PasswordSeed();
+
+            case ProtocolConstants.MI_PASSWORD:
+                _state = State.Online;
+                return replies.Ack();
+
+            case ProtocolConstants.MI_HEARTBEAT_POLL:
+                return replies.StatusReply(mem, clock());
+
+            case ProtocolConstants.MI_SIGN_CONFIGURATION_REQUEST:
+                return replies.ConfigReply();
+
+            case ProtocolConstants.MI_SIGN_SET_TEXT_FRAME:
+                mem.PutTextFrame(SetCommandParser.ParseTextFrame(a));
+                return replies.StatusReply(mem, clock());
+
+            case ProtocolConstants.MI_SIGN_SET_GRAPHIC_FRAME:
+                mem.PutGraphicsFrame(SetCommandParser.ParseGraphicsFrame(a));
+                return replies.StatusReply(mem, clock());
+
+            case ProtocolConstants.MI_SIGN_SET_HIGH_RESOLUTION_GRAPHICS_FRAME:
+                mem.PutHiResFrame(SetCommandParser.ParseHiResFrame(a));
+                return replies.StatusReply(mem, clock());
+
+            case ProtocolConstants.MI_SIGN_SET_MESSAGE:
+                mem.PutMessage(SetCommandParser.ParseMessage(a));
+                return replies.StatusReply(mem, clock());
+
+            case ProtocolConstants.MI_SIGN_SET_PLAN:
+                mem.PutPlan(SetCommandParser.ParsePlan(a));
+                return replies.StatusReply(mem, clock());
+
+            case ProtocolConstants.MI_SIGN_DISPLAY_FRAME:
+            {
+                byte frameId = Convert.ToByte(a[4..6], 16);
+                byte rev = mem.GetTextFrame(frameId)?.Revision
+                           ?? mem.GetGraphicsFrame(frameId)?.Revision
+                           ?? mem.GetHiResFrame(frameId)?.Revision ?? (byte)0;
+                mem.SetActiveFrame(frameId, rev);
+                return replies.Ack();
+            }
+
+            case ProtocolConstants.MI_SIGN_DISPLAY_MESSAGE:
+            {
+                byte msgId = Convert.ToByte(a[4..6], 16);
+                byte rev = mem.GetMessage(msgId)?.Revision ?? (byte)0;
+                mem.SetActiveMessage(msgId, rev);
+                return replies.Ack();
+            }
+
+            case ProtocolConstants.MI_SIGN_DISPLAY_ATOMIC_FRAMES:
+            {
+                byte numSigns = Convert.ToByte(a[4..6], 16);
+                if (numSigns > 0)
+                {
+                    int lastFrameOff = 6 + (numSigns - 1) * 4 + 2;
+                    byte frameId = Convert.ToByte(a[lastFrameOff..(lastFrameOff + 2)], 16);
+                    byte rev = mem.GetTextFrame(frameId)?.Revision ?? (byte)0;
+                    mem.SetActiveFrame(frameId, rev);
+                }
+                return replies.StatusReply(mem, clock());
+            }
+
+            case ProtocolConstants.MI_ENABLE_PLAN:
+            {
+                byte group = Convert.ToByte(a[2..4], 16);
+                byte planId = Convert.ToByte(a[4..6], 16);
+                _enabledPlans.Add((group, planId));
+                byte rev = mem.GetPlan(planId)?.Revision ?? (byte)0;
+                mem.SetActivePlan(planId, rev);
+                return replies.Ack();
+            }
+
+            case ProtocolConstants.MI_DISABLE_PLAN:
+            {
+                byte group = Convert.ToByte(a[2..4], 16);
+                byte planId = Convert.ToByte(a[4..6], 16);
+                _enabledPlans.Remove((group, planId));
+                return replies.Ack();
+            }
+
+            case ProtocolConstants.MI_REQUEST_ENABLED_PLANS:
+                return replies.ReportEnabledPlans(_enabledPlans.ToArray());
+
+            case ProtocolConstants.MI_SIGN_REQUEST_STORED_FRAME_MESSAGE_PLAN:
+                return RequestStored(a);
+
+            case ProtocolConstants.MI_END_SESSION:
+                _state = State.Idle;
+                return replies.Ack();
+
+            default:
+                return replies.Reject(data.Mi, UnsupportedErrorCode);
+        }
+    }
+
+    private string RequestStored(string a)
+    {
+        int requestType = Convert.ToInt32(a[2..4], 16);
+        byte id = Convert.ToByte(a[4..6], 16);
+
+        switch (requestType)
+        {
+            case RequestFrame:
+                if (mem.GetTextFrame(id) is { } tf) return SetCommandParser.BuildTextFrameAppData(tf);
+                if (mem.GetGraphicsFrame(id) is { } gf) return SetCommandParser.BuildGraphicsFrameAppData(gf);
+                if (mem.GetHiResFrame(id) is { } hf) return SetCommandParser.BuildHiResFrameAppData(hf);
+                break;
+            case RequestMessage:
+                if (mem.GetMessage(id) is { } m) return SetCommandParser.BuildMessageAppData(m);
+                break;
+            case RequestPlan:
+                if (mem.GetPlan(id) is { } p) return SetCommandParser.BuildPlanAppData(p);
+                break;
+        }
+        return replies.Reject(ProtocolConstants.MI_SIGN_REQUEST_STORED_FRAME_MESSAGE_PLAN, NotFoundErrorCode);
+    }
+
+    private static int Increment(int current) => current is 0 or >= 255 ? 1 : current + 1;
+}

--- a/src/TSISP003.Simulator/Session/SimulatorSession.cs
+++ b/src/TSISP003.Simulator/Session/SimulatorSession.cs
@@ -51,7 +51,9 @@ public class SimulatorSession(
             _nr = Increment(data.Ns);
             output.Add(PacketCodec.BuildAck(_nr, options.Address));
 
-            string? reply = Dispatch(data);
+            string? reply;
+            try { reply = Dispatch(data); }
+            catch (Exception) { reply = replies.Reject(data.Mi, UnsupportedErrorCode); }
             if (reply is not null)
             {
                 output.Add(PacketCodec.BuildData(_ns, _nr, options.Address, reply));
@@ -71,6 +73,9 @@ public class SimulatorSession(
                 return replies.PasswordSeed();
 
             case ProtocolConstants.MI_PASSWORD:
+                // Intentionally accepts any password without validation — the simulator is a
+                // test harness, not a security boundary. SimulatorOptions.SeedOffset and
+                // PasswordOffset are therefore unused by the session.
                 _state = State.Online;
                 return replies.Ack();
 

--- a/src/TSISP003.Simulator/Session/SimulatorSession.cs
+++ b/src/TSISP003.Simulator/Session/SimulatorSession.cs
@@ -107,44 +107,43 @@ public class SimulatorSession(
 
             case ProtocolConstants.MI_SIGN_DISPLAY_FRAME:
             {
+                // Group-level: display the frame on every sign in the group.
                 byte frameId = Convert.ToByte(a[4..6], 16);
-                byte rev = mem.GetTextFrame(frameId)?.Revision
-                           ?? mem.GetGraphicsFrame(frameId)?.Revision
-                           ?? mem.GetHiResFrame(frameId)?.Revision ?? (byte)0;
-                mem.SetActiveFrame(frameId, rev);
+                mem.SetActiveFrameAll(frameId, FrameRevision(frameId));
                 return replies.Ack();
             }
 
             case ProtocolConstants.MI_SIGN_DISPLAY_MESSAGE:
             {
+                // Group-level: display the message on every sign in the group.
                 byte msgId = Convert.ToByte(a[4..6], 16);
                 byte rev = mem.GetMessage(msgId)?.Revision ?? (byte)0;
-                mem.SetActiveMessage(msgId, rev);
+                mem.SetActiveMessageAll(msgId, rev);
                 return replies.Ack();
             }
 
             case ProtocolConstants.MI_SIGN_DISPLAY_ATOMIC_FRAMES:
             {
+                // Per-sign: each (SignID, FrameID) pair sets that sign's active frame.
                 byte numSigns = Convert.ToByte(a[4..6], 16);
-                if (numSigns > 0)
+                for (int i = 0; i < numSigns; i++)
                 {
-                    int lastFrameOff = 6 + (numSigns - 1) * 4 + 2;
-                    byte frameId = Convert.ToByte(a[lastFrameOff..(lastFrameOff + 2)], 16);
-                    byte rev = mem.GetTextFrame(frameId)?.Revision
-                               ?? mem.GetGraphicsFrame(frameId)?.Revision
-                               ?? mem.GetHiResFrame(frameId)?.Revision ?? (byte)0;
-                    mem.SetActiveFrame(frameId, rev);
+                    int off = 6 + i * 4;
+                    byte signId = Convert.ToByte(a[off..(off + 2)], 16);
+                    byte frameId = Convert.ToByte(a[(off + 2)..(off + 4)], 16);
+                    mem.SetActiveFrameForSign(signId, frameId, FrameRevision(frameId));
                 }
                 return replies.StatusReply(mem, clock());
             }
 
             case ProtocolConstants.MI_ENABLE_PLAN:
             {
+                // Group-level: enable the plan on every sign in the group.
                 byte group = Convert.ToByte(a[2..4], 16);
                 byte planId = Convert.ToByte(a[4..6], 16);
                 _enabledPlans.Add((group, planId));
                 byte rev = mem.GetPlan(planId)?.Revision ?? (byte)0;
-                mem.SetActivePlan(planId, rev);
+                mem.SetActivePlanAll(planId, rev);
                 return replies.Ack();
             }
 
@@ -192,6 +191,12 @@ public class SimulatorSession(
         }
         return replies.Reject(ProtocolConstants.MI_SIGN_REQUEST_STORED_FRAME_MESSAGE_PLAN, NotFoundErrorCode);
     }
+
+    /// <summary>Revision of a stored frame (text, graphics, or hi-res), or 0 if not stored.</summary>
+    private byte FrameRevision(byte frameId)
+        => mem.GetTextFrame(frameId)?.Revision
+           ?? mem.GetGraphicsFrame(frameId)?.Revision
+           ?? mem.GetHiResFrame(frameId)?.Revision ?? (byte)0;
 
     private static int Increment(int current) => current is 0 or >= 255 ? 1 : current + 1;
 }

--- a/src/TSISP003.Simulator/Storage/SimulatorMemory.cs
+++ b/src/TSISP003.Simulator/Storage/SimulatorMemory.cs
@@ -2,8 +2,10 @@ namespace TSISP003.Simulator.Storage;
 
 /// <summary>
 /// In-memory store for the simulator's frames, messages, plans, and display state.
-/// Not internally synchronized: callers must hold <see cref="Gate"/> when reading or
-/// mutating state from more than one thread.
+/// All mutators and accessors are internally synchronized on <see cref="Gate"/>.
+/// Callers may still take <see cref="Gate"/> themselves to read an atomic multi-field
+/// snapshot (as <c>SimulatorReplyBuilder.StatusReply</c> does); C# Monitor is
+/// reentrant, so the internal locks compose safely.
 /// </summary>
 public class SimulatorMemory
 {
@@ -21,24 +23,30 @@ public class SimulatorMemory
     public byte ActiveMessageRevision { get; private set; }
     public byte ActivePlanId { get; private set; }
     public byte ActivePlanRevision { get; private set; }
-    public bool SignEnabled { get; set; } = true;
 
-    public void PutTextFrame(StoredTextFrame f) => _text[f.FrameId] = f;
-    public StoredTextFrame? GetTextFrame(byte id) => _text.TryGetValue(id, out var f) ? f : null;
+    private bool _signEnabled = true;
+    public bool SignEnabled
+    {
+        get { lock (Gate) { return _signEnabled; } }
+        set { lock (Gate) { _signEnabled = value; } }
+    }
 
-    public void PutGraphicsFrame(StoredGraphicsFrame f) => _graphics[f.FrameId] = f;
-    public StoredGraphicsFrame? GetGraphicsFrame(byte id) => _graphics.TryGetValue(id, out var f) ? f : null;
+    public void PutTextFrame(StoredTextFrame f) { lock (Gate) { _text[f.FrameId] = f; } }
+    public StoredTextFrame? GetTextFrame(byte id) { lock (Gate) { return _text.TryGetValue(id, out var f) ? f : null; } }
 
-    public void PutHiResFrame(StoredHiResFrame f) => _hiRes[f.FrameId] = f;
-    public StoredHiResFrame? GetHiResFrame(byte id) => _hiRes.TryGetValue(id, out var f) ? f : null;
+    public void PutGraphicsFrame(StoredGraphicsFrame f) { lock (Gate) { _graphics[f.FrameId] = f; } }
+    public StoredGraphicsFrame? GetGraphicsFrame(byte id) { lock (Gate) { return _graphics.TryGetValue(id, out var f) ? f : null; } }
 
-    public void PutMessage(StoredMessage m) => _messages[m.MessageId] = m;
-    public StoredMessage? GetMessage(byte id) => _messages.TryGetValue(id, out var m) ? m : null;
+    public void PutHiResFrame(StoredHiResFrame f) { lock (Gate) { _hiRes[f.FrameId] = f; } }
+    public StoredHiResFrame? GetHiResFrame(byte id) { lock (Gate) { return _hiRes.TryGetValue(id, out var f) ? f : null; } }
 
-    public void PutPlan(StoredPlan p) => _plans[p.PlanId] = p;
-    public StoredPlan? GetPlan(byte id) => _plans.TryGetValue(id, out var p) ? p : null;
+    public void PutMessage(StoredMessage m) { lock (Gate) { _messages[m.MessageId] = m; } }
+    public StoredMessage? GetMessage(byte id) { lock (Gate) { return _messages.TryGetValue(id, out var m) ? m : null; } }
 
-    public void SetActiveFrame(byte id, byte rev) { ActiveFrameId = id; ActiveFrameRevision = rev; }
-    public void SetActiveMessage(byte id, byte rev) { ActiveMessageId = id; ActiveMessageRevision = rev; }
-    public void SetActivePlan(byte id, byte rev) { ActivePlanId = id; ActivePlanRevision = rev; }
+    public void PutPlan(StoredPlan p) { lock (Gate) { _plans[p.PlanId] = p; } }
+    public StoredPlan? GetPlan(byte id) { lock (Gate) { return _plans.TryGetValue(id, out var p) ? p : null; } }
+
+    public void SetActiveFrame(byte id, byte rev) { lock (Gate) { ActiveFrameId = id; ActiveFrameRevision = rev; } }
+    public void SetActiveMessage(byte id, byte rev) { lock (Gate) { ActiveMessageId = id; ActiveMessageRevision = rev; } }
+    public void SetActivePlan(byte id, byte rev) { lock (Gate) { ActivePlanId = id; ActivePlanRevision = rev; } }
 }

--- a/src/TSISP003.Simulator/Storage/SimulatorMemory.cs
+++ b/src/TSISP003.Simulator/Storage/SimulatorMemory.cs
@@ -1,14 +1,19 @@
 namespace TSISP003.Simulator.Storage;
 
+/// <summary>
+/// In-memory store for the simulator's frames, messages, plans, and display state.
+/// Not internally synchronized: callers must hold <see cref="Gate"/> when reading or
+/// mutating state from more than one thread.
+/// </summary>
 public class SimulatorMemory
 {
     public object Gate { get; } = new();
 
-    private readonly Dictionary<byte, StoredTextFrame> _text = new();
-    private readonly Dictionary<byte, StoredGraphicsFrame> _graphics = new();
-    private readonly Dictionary<byte, StoredHiResFrame> _hiRes = new();
-    private readonly Dictionary<byte, StoredMessage> _messages = new();
-    private readonly Dictionary<byte, StoredPlan> _plans = new();
+    private readonly Dictionary<byte, StoredTextFrame> _text = [];
+    private readonly Dictionary<byte, StoredGraphicsFrame> _graphics = [];
+    private readonly Dictionary<byte, StoredHiResFrame> _hiRes = [];
+    private readonly Dictionary<byte, StoredMessage> _messages = [];
+    private readonly Dictionary<byte, StoredPlan> _plans = [];
 
     public byte ActiveFrameId { get; private set; }
     public byte ActiveFrameRevision { get; private set; }

--- a/src/TSISP003.Simulator/Storage/SimulatorMemory.cs
+++ b/src/TSISP003.Simulator/Storage/SimulatorMemory.cs
@@ -1,0 +1,39 @@
+namespace TSISP003.Simulator.Storage;
+
+public class SimulatorMemory
+{
+    public object Gate { get; } = new();
+
+    private readonly Dictionary<byte, StoredTextFrame> _text = new();
+    private readonly Dictionary<byte, StoredGraphicsFrame> _graphics = new();
+    private readonly Dictionary<byte, StoredHiResFrame> _hiRes = new();
+    private readonly Dictionary<byte, StoredMessage> _messages = new();
+    private readonly Dictionary<byte, StoredPlan> _plans = new();
+
+    public byte ActiveFrameId { get; private set; }
+    public byte ActiveFrameRevision { get; private set; }
+    public byte ActiveMessageId { get; private set; }
+    public byte ActiveMessageRevision { get; private set; }
+    public byte ActivePlanId { get; private set; }
+    public byte ActivePlanRevision { get; private set; }
+    public bool SignEnabled { get; set; } = true;
+
+    public void PutTextFrame(StoredTextFrame f) => _text[f.FrameId] = f;
+    public StoredTextFrame? GetTextFrame(byte id) => _text.TryGetValue(id, out var f) ? f : null;
+
+    public void PutGraphicsFrame(StoredGraphicsFrame f) => _graphics[f.FrameId] = f;
+    public StoredGraphicsFrame? GetGraphicsFrame(byte id) => _graphics.TryGetValue(id, out var f) ? f : null;
+
+    public void PutHiResFrame(StoredHiResFrame f) => _hiRes[f.FrameId] = f;
+    public StoredHiResFrame? GetHiResFrame(byte id) => _hiRes.TryGetValue(id, out var f) ? f : null;
+
+    public void PutMessage(StoredMessage m) => _messages[m.MessageId] = m;
+    public StoredMessage? GetMessage(byte id) => _messages.TryGetValue(id, out var m) ? m : null;
+
+    public void PutPlan(StoredPlan p) => _plans[p.PlanId] = p;
+    public StoredPlan? GetPlan(byte id) => _plans.TryGetValue(id, out var p) ? p : null;
+
+    public void SetActiveFrame(byte id, byte rev) { ActiveFrameId = id; ActiveFrameRevision = rev; }
+    public void SetActiveMessage(byte id, byte rev) { ActiveMessageId = id; ActiveMessageRevision = rev; }
+    public void SetActivePlan(byte id, byte rev) { ActivePlanId = id; ActivePlanRevision = rev; }
+}

--- a/src/TSISP003.Simulator/Storage/SimulatorMemory.cs
+++ b/src/TSISP003.Simulator/Storage/SimulatorMemory.cs
@@ -1,14 +1,30 @@
 namespace TSISP003.Simulator.Storage;
 
+/// <summary>Immutable snapshot of one sign's display state, returned by <see cref="SimulatorMemory.SnapshotSigns"/>.</summary>
+public readonly record struct SignSnapshot(
+    byte SignId,
+    byte FrameId, byte FrameRevision,
+    byte MessageId, byte MessageRevision,
+    byte PlanId, byte PlanRevision,
+    bool Enabled);
+
 /// <summary>
-/// In-memory store for the simulator's frames, messages, plans, and display state.
-/// All mutators and accessors are internally synchronized on <see cref="Gate"/>.
-/// Callers may still take <see cref="Gate"/> themselves to read an atomic multi-field
-/// snapshot (as <c>SimulatorReplyBuilder.StatusReply</c> does); C# Monitor is
-/// reentrant, so the internal locks compose safely.
+/// In-memory store for one controller's frames, messages, plans, and per-sign display state.
+/// Stored frames/messages/plans are device-wide; display state is tracked per sign so that
+/// atomic display can differ between signs while group display affects all signs.
+/// All mutators and accessors are internally synchronized on <see cref="Gate"/>; C# Monitor
+/// is reentrant, so the internal locks compose with an outer caller-held <see cref="Gate"/>.
 /// </summary>
 public class SimulatorMemory
 {
+    private sealed class SignDisplayState
+    {
+        public byte FrameId, FrameRevision;
+        public byte MessageId, MessageRevision;
+        public byte PlanId, PlanRevision;
+        public bool Enabled = true;
+    }
+
     public object Gate { get; } = new();
 
     private readonly Dictionary<byte, StoredTextFrame> _text = [];
@@ -17,20 +33,25 @@ public class SimulatorMemory
     private readonly Dictionary<byte, StoredMessage> _messages = [];
     private readonly Dictionary<byte, StoredPlan> _plans = [];
 
-    public byte ActiveFrameId { get; private set; }
-    public byte ActiveFrameRevision { get; private set; }
-    public byte ActiveMessageId { get; private set; }
-    public byte ActiveMessageRevision { get; private set; }
-    public byte ActivePlanId { get; private set; }
-    public byte ActivePlanRevision { get; private set; }
+    private readonly Dictionary<byte, SignDisplayState> _signs = [];
 
-    private bool _signEnabled = true;
-    public bool SignEnabled
+    /// <summary>Sign IDs in this controller's single group (1..signCount).</summary>
+    public IReadOnlyList<byte> SignIds { get; }
+
+    public SimulatorMemory(int signCount = 1)
     {
-        get { lock (Gate) { return _signEnabled; } }
-        set { lock (Gate) { _signEnabled = value; } }
+        if (signCount < 1) signCount = 1;
+        var ids = new List<byte>(signCount);
+        for (int i = 1; i <= signCount; i++)
+        {
+            var id = (byte)i;
+            ids.Add(id);
+            _signs[id] = new SignDisplayState();
+        }
+        SignIds = ids;
     }
 
+    // ---- Device-wide stores ----
     public void PutTextFrame(StoredTextFrame f) { lock (Gate) { _text[f.FrameId] = f; } }
     public StoredTextFrame? GetTextFrame(byte id) { lock (Gate) { return _text.TryGetValue(id, out var f) ? f : null; } }
 
@@ -46,7 +67,45 @@ public class SimulatorMemory
     public void PutPlan(StoredPlan p) { lock (Gate) { _plans[p.PlanId] = p; } }
     public StoredPlan? GetPlan(byte id) { lock (Gate) { return _plans.TryGetValue(id, out var p) ? p : null; } }
 
-    public void SetActiveFrame(byte id, byte rev) { lock (Gate) { ActiveFrameId = id; ActiveFrameRevision = rev; } }
-    public void SetActiveMessage(byte id, byte rev) { lock (Gate) { ActiveMessageId = id; ActiveMessageRevision = rev; } }
-    public void SetActivePlan(byte id, byte rev) { lock (Gate) { ActivePlanId = id; ActivePlanRevision = rev; } }
+    // ---- Group-level display (affects every sign in the group) ----
+    public void SetActiveFrameAll(byte id, byte rev)
+    {
+        lock (Gate) { foreach (var s in _signs.Values) { s.FrameId = id; s.FrameRevision = rev; } }
+    }
+
+    public void SetActiveMessageAll(byte id, byte rev)
+    {
+        lock (Gate) { foreach (var s in _signs.Values) { s.MessageId = id; s.MessageRevision = rev; } }
+    }
+
+    public void SetActivePlanAll(byte id, byte rev)
+    {
+        lock (Gate) { foreach (var s in _signs.Values) { s.PlanId = id; s.PlanRevision = rev; } }
+    }
+
+    public void SetSignEnabledAll(bool enabled)
+    {
+        lock (Gate) { foreach (var s in _signs.Values) s.Enabled = enabled; }
+    }
+
+    // ---- Per-sign display (atomic frame display) ----
+    public void SetActiveFrameForSign(byte signId, byte id, byte rev)
+    {
+        lock (Gate) { if (_signs.TryGetValue(signId, out var s)) { s.FrameId = id; s.FrameRevision = rev; } }
+    }
+
+    /// <summary>Atomic, ordered snapshot of every sign's display state.</summary>
+    public List<SignSnapshot> SnapshotSigns()
+    {
+        lock (Gate)
+        {
+            var result = new List<SignSnapshot>(SignIds.Count);
+            foreach (var id in SignIds)
+            {
+                var s = _signs[id];
+                result.Add(new SignSnapshot(id, s.FrameId, s.FrameRevision, s.MessageId, s.MessageRevision, s.PlanId, s.PlanRevision, s.Enabled));
+            }
+            return result;
+        }
+    }
 }

--- a/src/TSISP003.Simulator/Storage/StoredItems.cs
+++ b/src/TSISP003.Simulator/Storage/StoredItems.cs
@@ -1,0 +1,8 @@
+namespace TSISP003.Simulator.Storage;
+
+public record StoredTextFrame(byte FrameId, byte Revision, byte Font, byte Colour, byte Conspicuity, byte NumChars, string TextHex);
+public record StoredGraphicsFrame(byte FrameId, byte Revision, byte Rows, byte Cols, byte Colour, byte Conspicuity, ushort Length, string DataHex);
+public record StoredHiResFrame(byte FrameId, byte Revision, ushort Rows, ushort Cols, byte Colour, byte Conspicuity, uint Length, string DataHex);
+public record StoredMessage(byte MessageId, byte Revision, byte TransitionTime, (byte Id, byte Time)[] Frames);
+public record StoredPlanEntry(byte Type, byte Id, byte StartHour, byte StartMin, byte StopHour, byte StopMin);
+public record StoredPlan(byte PlanId, byte Revision, byte DayOfWeek, StoredPlanEntry[] Entries);

--- a/src/TSISP003.Simulator/TSISP003.Simulator.csproj
+++ b/src/TSISP003.Simulator/TSISP003.Simulator.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TSISP003.Protocol\TSISP003.Protocol.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/TSISP003.Simulator/TSISP003.Simulator.csproj
+++ b/src/TSISP003.Simulator/TSISP003.Simulator.csproj
@@ -8,10 +8,16 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\TSISP003.Protocol\TSISP003.Protocol.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/src/TSISP003.Simulator/Tcp/SimulatorListener.cs
+++ b/src/TSISP003.Simulator/Tcp/SimulatorListener.cs
@@ -14,7 +14,7 @@ public class SimulatorListener(SimulatorOptions options, ILogger<SimulatorListen
     : BackgroundService
 {
     private readonly TcpListener _listener = new(IPAddress.Any, options.Port);
-    private readonly SimulatorMemory _memory = new();
+    private readonly SimulatorMemory _memory = new(options.SignCount);
 
     public int BoundPort => ((IPEndPoint)_listener.LocalEndpoint).Port;
 

--- a/src/TSISP003.Simulator/Tcp/SimulatorListener.cs
+++ b/src/TSISP003.Simulator/Tcp/SimulatorListener.cs
@@ -20,13 +20,20 @@ public class SimulatorListener(SimulatorOptions options, ILogger<SimulatorListen
 
     public void Start()
     {
+        // Test helper: bind the port synchronously so BoundPort is readable, then
+        // start the BackgroundService accept loop (StartAsync wires up ExecuteTask).
         _listener.Start();
-        StartAsync(CancellationToken.None);
+        _ = StartAsync(CancellationToken.None);
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        if (!_listener.Server.IsBound) _listener.Start();
+        try { if (!_listener.Server.IsBound) _listener.Start(); }
+        catch (SocketException ex)
+        {
+            logger.LogCritical(ex, "TSISP003 simulator could not bind port {Port} (in use?). Shutting down.", options.Port);
+            return;
+        }
         logger.LogInformation("TSISP003 simulator listening on port {Port}", BoundPort);
 
         while (!stoppingToken.IsCancellationRequested)

--- a/src/TSISP003.Simulator/Tcp/SimulatorListener.cs
+++ b/src/TSISP003.Simulator/Tcp/SimulatorListener.cs
@@ -15,15 +15,13 @@ public class SimulatorListener(SimulatorOptions options, ILogger<SimulatorListen
 {
     private readonly TcpListener _listener = new(IPAddress.Any, options.Port);
     private readonly SimulatorMemory _memory = new();
-    private CancellationTokenSource? _cts;
 
     public int BoundPort => ((IPEndPoint)_listener.LocalEndpoint).Port;
 
     public void Start()
     {
         _listener.Start();
-        _cts = new CancellationTokenSource();
-        _ = ExecuteAsync(_cts.Token);
+        StartAsync(CancellationToken.None);
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -69,15 +67,8 @@ public class SimulatorListener(SimulatorOptions options, ILogger<SimulatorListen
         }
     }
 
-    public override Task StopAsync(CancellationToken cancellationToken)
-    {
-        _cts?.Cancel();
-        return base.StopAsync(cancellationToken);
-    }
-
     public override void Dispose()
     {
-        _cts?.Dispose();
         _listener.Dispose();
         base.Dispose();
     }

--- a/src/TSISP003.Simulator/Tcp/SimulatorListener.cs
+++ b/src/TSISP003.Simulator/Tcp/SimulatorListener.cs
@@ -1,0 +1,84 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using TSISP003.Simulator.Configuration;
+using TSISP003.Simulator.Protocol;
+using TSISP003.Simulator.Session;
+using TSISP003.Simulator.Storage;
+
+namespace TSISP003.Simulator.Tcp;
+
+public class SimulatorListener(SimulatorOptions options, ILogger<SimulatorListener> logger)
+    : BackgroundService
+{
+    private readonly TcpListener _listener = new(IPAddress.Any, options.Port);
+    private readonly SimulatorMemory _memory = new();
+    private CancellationTokenSource? _cts;
+
+    public int BoundPort => ((IPEndPoint)_listener.LocalEndpoint).Port;
+
+    public void Start()
+    {
+        _listener.Start();
+        _cts = new CancellationTokenSource();
+        _ = ExecuteAsync(_cts.Token);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!_listener.Server.IsBound) _listener.Start();
+        logger.LogInformation("TSISP003 simulator listening on port {Port}", BoundPort);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            TcpClient client;
+            try { client = await _listener.AcceptTcpClientAsync(stoppingToken); }
+            catch (OperationCanceledException) { break; }
+
+            _ = HandleClientAsync(client, stoppingToken);
+        }
+    }
+
+    private async Task HandleClientAsync(TcpClient client, CancellationToken token)
+    {
+        var replies = new SimulatorReplyBuilder(options);
+        var session = new SimulatorSession(_memory, replies, options, () => DateTime.Now);
+        using (client)
+        {
+            var stream = client.GetStream();
+            var buffer = new byte[4096];
+            try
+            {
+                int read;
+                while ((read = await stream.ReadAsync(buffer, token)) > 0)
+                {
+                    string incoming = Encoding.ASCII.GetString(buffer, 0, read);
+                    foreach (var packet in session.Handle(incoming))
+                    {
+                        byte[] outBytes = Encoding.ASCII.GetBytes(packet);
+                        await stream.WriteAsync(outBytes, token);
+                    }
+                }
+            }
+            catch (Exception ex) when (ex is IOException or OperationCanceledException)
+            {
+                logger.LogDebug("Client disconnected: {Message}", ex.Message);
+            }
+        }
+    }
+
+    public override Task StopAsync(CancellationToken cancellationToken)
+    {
+        _cts?.Cancel();
+        return base.StopAsync(cancellationToken);
+    }
+
+    public override void Dispose()
+    {
+        _cts?.Dispose();
+        _listener.Dispose();
+        base.Dispose();
+    }
+}

--- a/src/TSISP003.Simulator/appsettings.json
+++ b/src/TSISP003.Simulator/appsettings.json
@@ -1,7 +1,7 @@
 {
   "Simulator": {
     "Address": "01",
-    "Port": 5000,
+    "Port": 5050,
     "SeedOffset": "00",
     "PasswordOffset": "00",
     "Seed": 18

--- a/src/TSISP003.Simulator/appsettings.json
+++ b/src/TSISP003.Simulator/appsettings.json
@@ -1,9 +1,9 @@
 {
   "Simulator": {
-    "Address": "01",
-    "Port": 5050,
-    "SeedOffset": "00",
-    "PasswordOffset": "00",
-    "Seed": 18
+    "Controllers": [
+      { "Name": "controller-1", "Address": "01", "Port": 5050, "Seed": 18, "SeedOffset": "00", "PasswordOffset": "00", "SignCount": 3 },
+      { "Name": "controller-2", "Address": "02", "Port": 5051, "Seed": 18, "SeedOffset": "00", "PasswordOffset": "00", "SignCount": 3 },
+      { "Name": "controller-3", "Address": "03", "Port": 5052, "Seed": 18, "SeedOffset": "00", "PasswordOffset": "00", "SignCount": 3 }
+    ]
   }
 }

--- a/src/TSISP003.Simulator/appsettings.json
+++ b/src/TSISP003.Simulator/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Simulator": {
+    "Address": "01",
+    "Port": 5000,
+    "SeedOffset": "00",
+    "PasswordOffset": "00",
+    "Seed": 18
+  }
+}

--- a/tests/TSISP003.Tests/Protocol/PacketCodecTests.cs
+++ b/tests/TSISP003.Tests/Protocol/PacketCodecTests.cs
@@ -1,0 +1,59 @@
+using TSISP003.Protocol;
+using Xunit;
+
+namespace TSISP003.Tests.Protocol;
+
+public class PacketCodecTests
+{
+    [Fact]
+    public void BuildData_ThenTryParse_RoundTrips()
+    {
+        // appdata = MI 06 + one byte payload "AB"
+        string packet = PacketCodec.BuildData(ns: 1, nr: 2, addr: "01", appDataWithMi: "06AB");
+
+        Assert.Equal(ProtocolConstants.SOH, packet[0]);
+        Assert.Equal(ProtocolConstants.ETX, packet[^1]);
+
+        Assert.True(PacketCodec.TryParse(packet, out var data, out char kind));
+        Assert.Equal('D', kind);
+        Assert.Equal(1, data.Ns);
+        Assert.Equal(2, data.Nr);
+        Assert.Equal("01", data.Addr);
+        Assert.Equal(0x06, data.Mi);
+        Assert.Equal("06AB", data.AppData);
+    }
+
+    [Fact]
+    public void BuildData_CrcVerifies()
+    {
+        string packet = PacketCodec.BuildData(0, 0, "01", "05");
+        Assert.True(PacketCodec.VerifyCrc(packet));
+    }
+
+    [Fact]
+    public void BuildData_TamperedCrc_FailsVerify()
+    {
+        string packet = PacketCodec.BuildData(0, 0, "01", "05");
+        // flip a char in the appdata region (index 8 is MI high nibble)
+        char[] chars = packet.ToCharArray();
+        chars[8] = chars[8] == '0' ? '1' : '0';
+        Assert.False(PacketCodec.VerifyCrc(new string(chars)));
+    }
+
+    [Fact]
+    public void BuildAck_ParsesAsAck_WithNrAndAddr()
+    {
+        string ack = PacketCodec.BuildAck(nr: 3, addr: "01");
+        Assert.Equal(ProtocolConstants.ACK, ack[0]);
+        Assert.True(PacketCodec.TryParse(ack, out var data, out char kind));
+        Assert.Equal('A', kind);
+        Assert.Equal(3, data.Nr);
+        Assert.Equal("01", data.Addr);
+    }
+
+    [Fact]
+    public void TryParse_Garbage_ReturnsFalse()
+    {
+        Assert.False(PacketCodec.TryParse("not a packet", out _, out _));
+    }
+}

--- a/tests/TSISP003.Tests/Protocol/PacketCodecTests.cs
+++ b/tests/TSISP003.Tests/Protocol/PacketCodecTests.cs
@@ -56,4 +56,13 @@ public class PacketCodecTests
     {
         Assert.False(PacketCodec.TryParse("not a packet", out _, out _));
     }
+
+    [Fact]
+    public void TryParse_DataPacketWithEmptyAppData_ReturnsFalse()
+    {
+        // SOH + NS + NR + ADDR + STX + (no appdata) + CRC(4) + ETX
+        string body = ProtocolConstants.SOH + "0000" + "01" + ProtocolConstants.STX;
+        string packet = body + "0000" + ProtocolConstants.ETX; // dummy 4-char CRC
+        Assert.False(PacketCodec.TryParse(packet, out _, out _));
+    }
 }

--- a/tests/TSISP003.Tests/Services/SignControllerServiceConfigTests.cs
+++ b/tests/TSISP003.Tests/Services/SignControllerServiceConfigTests.cs
@@ -1,5 +1,5 @@
 using TSISP003.Domain.Enums;
-using TSISP003.Infrastructure.Protocol;
+using TSISP003.Protocol;
 
 namespace TSISP003.Tests.Services;
 

--- a/tests/TSISP003.Tests/Services/SignControllerServiceTests.cs
+++ b/tests/TSISP003.Tests/Services/SignControllerServiceTests.cs
@@ -6,7 +6,7 @@ using TSISP003.Infrastructure.Services;
 using TSISP003.Domain.Entities;
 using TSISP003.Domain.Exceptions;
 using TSISP003.Domain.Enums;
-using TSISP003.Infrastructure.Protocol;
+using TSISP003.Protocol;
 
 namespace TSISP003.Tests.Services;
 

--- a/tests/TSISP003.Tests/Services/SignControllerServiceTests.cs
+++ b/tests/TSISP003.Tests/Services/SignControllerServiceTests.cs
@@ -29,7 +29,7 @@ public class SignControllerServiceTests : IDisposable
             PasswordOffset = "1234",
             SeedOffset = "56"
         };
-        _service = new SignControllerService(_mockTcpClient.Object, _deviceSettings, _mockLogger.Object);
+        _service = new SignControllerService(_mockTcpClient.Object, _deviceSettings, "test-device", _mockLogger.Object);
     }
 
     public void Dispose()

--- a/tests/TSISP003.Tests/Services/SignControllerServiceTests.cs
+++ b/tests/TSISP003.Tests/Services/SignControllerServiceTests.cs
@@ -60,7 +60,7 @@ public class SignControllerServiceTests : IDisposable
     }
 
     [Fact]
-    public void NS_ThreadSafe_ConcurrentAccess()
+    public async Task NS_ThreadSafe_ConcurrentAccess()
     {
         // Test thread-safe access
         var tasks = new List<Task>();
@@ -70,7 +70,7 @@ public class SignControllerServiceTests : IDisposable
             tasks.Add(Task.Run(() => _service.NS = value));
         }
 
-        Task.WaitAll(tasks.ToArray());
+        await Task.WhenAll(tasks);
 
         // Just verify it doesn't throw and has a valid value
         Assert.InRange(_service.NS, 0, 255);
@@ -101,7 +101,7 @@ public class SignControllerServiceTests : IDisposable
     }
 
     [Fact]
-    public void NR_ThreadSafe_ConcurrentAccess()
+    public async Task NR_ThreadSafe_ConcurrentAccess()
     {
         var tasks = new List<Task>();
         for (int i = 0; i < 100; i++)
@@ -110,7 +110,7 @@ public class SignControllerServiceTests : IDisposable
             tasks.Add(Task.Run(() => _service.NR = value));
         }
 
-        Task.WaitAll(tasks.ToArray());
+        await Task.WhenAll(tasks);
 
         Assert.InRange(_service.NR, 0, 255);
     }
@@ -705,7 +705,7 @@ public class SignControllerServiceTests : IDisposable
     #region GetStatus Tests
 
     [Fact]
-    public async Task GetStatus_ReturnsTask()
+    public void GetStatus_ReturnsTask()
     {
         // Act
         var statusTask = _service.GetStatus();

--- a/tests/TSISP003.Tests/Simulator/SetCommandParserTests.cs
+++ b/tests/TSISP003.Tests/Simulator/SetCommandParserTests.cs
@@ -9,7 +9,7 @@ public class SetCommandParserTests
     [Fact]
     public void TextFrame_BuildThenParse_RoundTrips()
     {
-        var f = new StoredTextFrame(7, 1, 0, 0, 0, 5, "48454C4C4F"); // HELLO
+        var f = new StoredTextFrame(7, 1, 2, 3, 4, 5, "48454C4C4F"); // HELLO
         string appData = SetCommandParser.BuildTextFrameAppData(f);
 
         Assert.Equal("0A", appData[0..2]);
@@ -43,6 +43,8 @@ public class SetCommandParserTests
         Assert.Equal("0C", appData[0..2]);
         var parsed = SetCommandParser.ParseMessage(appData);
         Assert.Equal((byte)2, parsed.MessageId);
+        Assert.Equal((byte)1, parsed.Revision);
+        Assert.Equal((byte)5, parsed.TransitionTime);
         Assert.Equal((7, 10), ((int)parsed.Frames[0].Id, (int)parsed.Frames[0].Time));
         Assert.Equal((8, 10), ((int)parsed.Frames[1].Id, (int)parsed.Frames[1].Time));
     }
@@ -55,6 +57,8 @@ public class SetCommandParserTests
         Assert.Equal("0D", appData[0..2]);
         var parsed = SetCommandParser.ParsePlan(appData);
         Assert.Equal((byte)1, parsed.PlanId);
+        Assert.Equal((byte)1, parsed.Revision);
+        Assert.Equal((byte)0x7F, parsed.DayOfWeek);
         Assert.Single(parsed.Entries);
         Assert.Equal(p.Entries[0], parsed.Entries[0]);
     }

--- a/tests/TSISP003.Tests/Simulator/SetCommandParserTests.cs
+++ b/tests/TSISP003.Tests/Simulator/SetCommandParserTests.cs
@@ -1,0 +1,61 @@
+using TSISP003.Simulator.Protocol;
+using TSISP003.Simulator.Storage;
+using Xunit;
+
+namespace TSISP003.Tests.Simulator;
+
+public class SetCommandParserTests
+{
+    [Fact]
+    public void TextFrame_BuildThenParse_RoundTrips()
+    {
+        var f = new StoredTextFrame(7, 1, 0, 0, 0, 5, "48454C4C4F"); // HELLO
+        string appData = SetCommandParser.BuildTextFrameAppData(f);
+
+        Assert.Equal("0A", appData[0..2]);
+        var parsed = SetCommandParser.ParseTextFrame(appData);
+        Assert.Equal(f, parsed);
+    }
+
+    [Fact]
+    public void GraphicsFrame_BuildThenParse_RoundTrips()
+    {
+        var f = new StoredGraphicsFrame(3, 2, 18, 48, 1, 0, 2, "ABCD");
+        string appData = SetCommandParser.BuildGraphicsFrameAppData(f);
+        Assert.Equal("0B", appData[0..2]);
+        Assert.Equal(f, SetCommandParser.ParseGraphicsFrame(appData));
+    }
+
+    [Fact]
+    public void HiResFrame_BuildThenParse_RoundTrips()
+    {
+        var f = new StoredHiResFrame(4, 1, 256, 512, 2, 0, 3, "AABBCC");
+        string appData = SetCommandParser.BuildHiResFrameAppData(f);
+        Assert.Equal("1D", appData[0..2]);
+        Assert.Equal(f, SetCommandParser.ParseHiResFrame(appData));
+    }
+
+    [Fact]
+    public void Message_BuildThenParse_RoundTrips()
+    {
+        var m = new StoredMessage(2, 1, 5, new (byte, byte)[] { (7, 10), (8, 10) });
+        string appData = SetCommandParser.BuildMessageAppData(m);
+        Assert.Equal("0C", appData[0..2]);
+        var parsed = SetCommandParser.ParseMessage(appData);
+        Assert.Equal((byte)2, parsed.MessageId);
+        Assert.Equal((7, 10), ((int)parsed.Frames[0].Id, (int)parsed.Frames[0].Time));
+        Assert.Equal((8, 10), ((int)parsed.Frames[1].Id, (int)parsed.Frames[1].Time));
+    }
+
+    [Fact]
+    public void Plan_BuildThenParse_RoundTrips()
+    {
+        var p = new StoredPlan(1, 1, 0x7F, new[] { new StoredPlanEntry(1, 7, 8, 0, 17, 30) });
+        string appData = SetCommandParser.BuildPlanAppData(p);
+        Assert.Equal("0D", appData[0..2]);
+        var parsed = SetCommandParser.ParsePlan(appData);
+        Assert.Equal((byte)1, parsed.PlanId);
+        Assert.Single(parsed.Entries);
+        Assert.Equal(p.Entries[0], parsed.Entries[0]);
+    }
+}

--- a/tests/TSISP003.Tests/Simulator/SimulatorListenerTests.cs
+++ b/tests/TSISP003.Tests/Simulator/SimulatorListenerTests.cs
@@ -1,0 +1,47 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using Microsoft.Extensions.Logging.Abstractions;
+using TSISP003.Protocol;
+using TSISP003.Simulator.Configuration;
+using TSISP003.Simulator.Tcp;
+using Xunit;
+
+namespace TSISP003.Tests.Simulator;
+
+public class SimulatorListenerTests
+{
+    [Fact]
+    public async Task StartSession_OverRealSocket_ReturnsSeed()
+    {
+        var options = new SimulatorOptions { Address = "01", Port = 0, Seed = 0x12 };
+        using var listener = new SimulatorListener(options, NullLogger<SimulatorListener>.Instance);
+        listener.Start();
+        int port = listener.BoundPort;
+
+        using var client = new TcpClient();
+        await client.ConnectAsync(IPAddress.Loopback, port);
+        var stream = client.GetStream();
+
+        string start = PacketCodec.BuildData(0, 0, "01", "02");
+        byte[] outBytes = Encoding.ASCII.GetBytes(start);
+        await stream.WriteAsync(outBytes);
+
+        // Read until we have received both the link-ACK and the data packet with the seed.
+        // Two WriteAsync calls in the listener may arrive in one or two reads.
+        var buffer = new byte[1024];
+        string response = string.Empty;
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        while (!response.Contains("0312"))
+        {
+            int read = await stream.ReadAsync(buffer, cts.Token);
+            if (read == 0) break;
+            response += Encoding.ASCII.GetString(buffer, 0, read);
+        }
+
+        // Response should contain the password-seed data packet "0312".
+        Assert.Contains("0312", response);
+
+        await listener.StopAsync(default);
+    }
+}

--- a/tests/TSISP003.Tests/Simulator/SimulatorMemoryTests.cs
+++ b/tests/TSISP003.Tests/Simulator/SimulatorMemoryTests.cs
@@ -12,29 +12,51 @@ public class SimulatorMemoryTests
         var frame = new StoredTextFrame(7, 1, 0, 0, 0, 5, "48454C4C4F"); // "HELLO"
         mem.PutTextFrame(frame);
 
-        var got = mem.GetTextFrame(7);
-        Assert.Equal(frame, got);
+        Assert.Equal(frame, mem.GetTextFrame(7));
     }
 
     [Fact]
     public void GetTextFrame_Unknown_ReturnsNull()
+        => Assert.Null(new SimulatorMemory().GetTextFrame(99));
+
+    [Fact]
+    public void DefaultSignCount_IsOneSign()
     {
-        var mem = new SimulatorMemory();
-        Assert.Null(mem.GetTextFrame(99));
+        var snap = new SimulatorMemory().SnapshotSigns();
+        Assert.Single(snap);
+        Assert.Equal((byte)1, snap[0].SignId);
     }
 
     [Fact]
-    public void SetActiveFrame_UpdatesDisplayState()
+    public void SignCount_CreatesSequentialSignIds()
+        => Assert.Equal(new byte[] { 1, 2, 3 }, new SimulatorMemory(3).SignIds);
+
+    [Fact]
+    public void SetActiveFrameAll_UpdatesEverySign()
     {
-        var mem = new SimulatorMemory();
-        mem.SetActiveFrame(7, 1);
-        Assert.Equal(7, mem.ActiveFrameId);
-        Assert.Equal(1, mem.ActiveFrameRevision);
+        var mem = new SimulatorMemory(3);
+        mem.SetActiveFrameAll(7, 2);
+
+        Assert.All(mem.SnapshotSigns(), s =>
+        {
+            Assert.Equal((byte)7, s.FrameId);
+            Assert.Equal((byte)2, s.FrameRevision);
+        });
+    }
+
+    [Fact]
+    public void SetActiveFrameForSign_UpdatesOnlyThatSign()
+    {
+        var mem = new SimulatorMemory(3);
+        mem.SetActiveFrameForSign(2, 9, 1);
+
+        var snap = mem.SnapshotSigns();
+        Assert.Equal((byte)0, snap[0].FrameId); // sign 1 untouched
+        Assert.Equal((byte)9, snap[1].FrameId); // sign 2 updated
+        Assert.Equal((byte)0, snap[2].FrameId); // sign 3 untouched
     }
 
     [Fact]
     public void SignEnabled_DefaultsTrue()
-    {
-        Assert.True(new SimulatorMemory().SignEnabled);
-    }
+        => Assert.All(new SimulatorMemory(3).SnapshotSigns(), s => Assert.True(s.Enabled));
 }

--- a/tests/TSISP003.Tests/Simulator/SimulatorMemoryTests.cs
+++ b/tests/TSISP003.Tests/Simulator/SimulatorMemoryTests.cs
@@ -1,0 +1,40 @@
+using TSISP003.Simulator.Storage;
+using Xunit;
+
+namespace TSISP003.Tests.Simulator;
+
+public class SimulatorMemoryTests
+{
+    [Fact]
+    public void PutThenGetTextFrame_ReturnsSameFrame()
+    {
+        var mem = new SimulatorMemory();
+        var frame = new StoredTextFrame(7, 1, 0, 0, 0, 5, "48454C4C4F"); // "HELLO"
+        mem.PutTextFrame(frame);
+
+        var got = mem.GetTextFrame(7);
+        Assert.Equal(frame, got);
+    }
+
+    [Fact]
+    public void GetTextFrame_Unknown_ReturnsNull()
+    {
+        var mem = new SimulatorMemory();
+        Assert.Null(mem.GetTextFrame(99));
+    }
+
+    [Fact]
+    public void SetActiveFrame_UpdatesDisplayState()
+    {
+        var mem = new SimulatorMemory();
+        mem.SetActiveFrame(7, 1);
+        Assert.Equal(7, mem.ActiveFrameId);
+        Assert.Equal(1, mem.ActiveFrameRevision);
+    }
+
+    [Fact]
+    public void SignEnabled_DefaultsTrue()
+    {
+        Assert.True(new SimulatorMemory().SignEnabled);
+    }
+}

--- a/tests/TSISP003.Tests/Simulator/SimulatorReplyBuilderTests.cs
+++ b/tests/TSISP003.Tests/Simulator/SimulatorReplyBuilderTests.cs
@@ -43,6 +43,8 @@ public class SimulatorReplyBuilderTests
         string app = NewBuilder().ConfigReply();
         Assert.Equal("22", app[0..2]);
         Assert.Equal("01", app[22..24]); // number of groups
+        Assert.Equal("3000", app[32..36]); // width 48, little-endian word
+        Assert.Equal("1200", app[36..40]); // height 18, little-endian word
     }
 
     [Fact]

--- a/tests/TSISP003.Tests/Simulator/SimulatorReplyBuilderTests.cs
+++ b/tests/TSISP003.Tests/Simulator/SimulatorReplyBuilderTests.cs
@@ -1,0 +1,56 @@
+using TSISP003.Simulator.Configuration;
+using TSISP003.Simulator.Protocol;
+using TSISP003.Simulator.Storage;
+using Xunit;
+
+namespace TSISP003.Tests.Simulator;
+
+public class SimulatorReplyBuilderTests
+{
+    private static SimulatorReplyBuilder NewBuilder() => new(new SimulatorOptions { Address = "01", Seed = 0x12 });
+
+    [Fact]
+    public void StatusReply_EncodesYearAsBigEndianWord_AndDecimalCountFields()
+    {
+        var mem = new SimulatorMemory();
+        mem.SetActiveFrame(7, 1);
+        var b = NewBuilder();
+
+        string app = b.StatusReply(mem, new DateTime(2025, 3, 4, 5, 6, 7));
+
+        Assert.Equal("06", app[0..2]);          // MI
+        Assert.Equal("01", app[2..4]);          // online
+        Assert.Equal("07E9", app[10..14]);      // year 2025 big-endian word
+        Assert.Equal("00", app[24..26]);        // controller error, decimal D2
+        Assert.Equal("01", app[26..28]);        // number of signs, decimal D2
+        // sign block (18 hex): SignID=01, err=00, enabled=01, frame=07, frameRev=01, msg=00, msgRev=00, plan=00, planRev=00
+        Assert.Equal("010001070100000000", app[28..46]);
+    }
+
+    [Fact]
+    public void Ack_IsMi01() => Assert.Equal("01", NewBuilder().Ack());
+
+    [Fact]
+    public void PasswordSeed_IsMi03PlusSeed() => Assert.Equal("0312", NewBuilder().PasswordSeed());
+
+    [Fact]
+    public void Reject_CarriesRejectedMiAndError()
+        => Assert.Equal("004005", NewBuilder().Reject(0x40, 5));
+
+    [Fact]
+    public void ConfigReply_HasOneGroupOneSign()
+    {
+        string app = NewBuilder().ConfigReply();
+        Assert.Equal("22", app[0..2]);
+        Assert.Equal("01", app[22..24]); // number of groups
+    }
+
+    [Fact]
+    public void ReportEnabledPlans_EncodesEntries()
+    {
+        string app = NewBuilder().ReportEnabledPlans(new[] { ((byte)1, (byte)5) });
+        Assert.Equal("13", app[0..2]);
+        Assert.Equal("01", app[2..4]);   // count
+        Assert.Equal("0105", app[4..8]); // group 1 plan 5
+    }
+}

--- a/tests/TSISP003.Tests/Simulator/SimulatorReplyBuilderTests.cs
+++ b/tests/TSISP003.Tests/Simulator/SimulatorReplyBuilderTests.cs
@@ -7,16 +7,16 @@ namespace TSISP003.Tests.Simulator;
 
 public class SimulatorReplyBuilderTests
 {
-    private static SimulatorReplyBuilder NewBuilder() => new(new SimulatorOptions { Address = "01", Seed = 0x12 });
+    private static SimulatorReplyBuilder NewBuilder(int signCount = 1)
+        => new(new SimulatorOptions { Address = "01", Seed = 0x12, SignCount = signCount });
 
     [Fact]
     public void StatusReply_EncodesYearAsBigEndianWord_AndDecimalCountFields()
     {
-        var mem = new SimulatorMemory();
-        mem.SetActiveFrame(7, 1);
-        var b = NewBuilder();
+        var mem = new SimulatorMemory(1);
+        mem.SetActiveFrameAll(7, 1);
 
-        string app = b.StatusReply(mem, new DateTime(2025, 3, 4, 5, 6, 7));
+        string app = NewBuilder(1).StatusReply(mem, new DateTime(2025, 3, 4, 5, 6, 7));
 
         Assert.Equal("06", app[0..2]);          // MI
         Assert.Equal("01", app[2..4]);          // online
@@ -25,6 +25,21 @@ public class SimulatorReplyBuilderTests
         Assert.Equal("01", app[26..28]);        // number of signs, decimal D2
         // sign block (18 hex): SignID=01, err=00, enabled=01, frame=07, frameRev=01, msg=00, msgRev=00, plan=00, planRev=00
         Assert.Equal("010001070100000000", app[28..46]);
+    }
+
+    [Fact]
+    public void StatusReply_ThreeSigns_EmitsThreeBlocksWithPerSignState()
+    {
+        var mem = new SimulatorMemory(3);
+        mem.SetActiveFrameAll(7, 1);            // group display: all signs frame 7 rev 1
+        mem.SetActiveFrameForSign(2, 9, 4);     // atomic override: sign 2 -> frame 9 rev 4
+
+        string app = NewBuilder(3).StatusReply(mem, new DateTime(2025, 1, 1, 0, 0, 0));
+
+        Assert.Equal("03", app[26..28]);                    // number of signs (decimal)
+        Assert.Equal("010001070100000000", app[28..46]);    // sign 1: frame 07 rev 01
+        Assert.Equal("020001090400000000", app[46..64]);    // sign 2: frame 09 rev 04
+        Assert.Equal("030001070100000000", app[64..82]);    // sign 3: frame 07 rev 01
     }
 
     [Fact]
@@ -38,13 +53,21 @@ public class SimulatorReplyBuilderTests
         => Assert.Equal("004005", NewBuilder().Reject(0x40, 5));
 
     [Fact]
-    public void ConfigReply_HasOneGroupOneSign()
+    public void ConfigReply_HasOneGroupThreeSigns()
     {
-        string app = NewBuilder().ConfigReply();
+        string app = NewBuilder(3).ConfigReply();
+
         Assert.Equal("22", app[0..2]);
-        Assert.Equal("01", app[22..24]); // number of groups
-        Assert.Equal("3000", app[32..36]); // width 48, little-endian word
-        Assert.Equal("1200", app[36..40]); // height 18, little-endian word
+        Assert.Equal("01", app[22..24]);            // number of groups
+        Assert.Equal("03", app[26..28]);            // number of signs in the group
+        // sign 1 entry [28..40]: id 01, type 00, width 3000 (48 LE), height 1200 (18 LE)
+        Assert.Equal("01", app[28..30]);            // sign 1 id
+        Assert.Equal("00", app[30..32]);            // sign 1 type (text)
+        Assert.Equal("3000", app[32..36]);          // sign 1 width 48 little-endian
+        Assert.Equal("1200", app[36..40]);          // sign 1 height 18 little-endian
+        Assert.Equal("02", app[40..42]);            // sign 2 id
+        Assert.Equal("03", app[52..54]);            // sign 3 id
+        Assert.Equal("00", app[64..66]);            // signature length
     }
 
     [Fact]

--- a/tests/TSISP003.Tests/Simulator/SimulatorSessionTests.cs
+++ b/tests/TSISP003.Tests/Simulator/SimulatorSessionTests.cs
@@ -1,0 +1,127 @@
+using TSISP003.Protocol;
+using TSISP003.Simulator.Configuration;
+using TSISP003.Simulator.Protocol;
+using TSISP003.Simulator.Session;
+using TSISP003.Simulator.Storage;
+using Xunit;
+
+namespace TSISP003.Tests.Simulator;
+
+public class SimulatorSessionTests
+{
+    private static SimulatorSession NewSession(SimulatorMemory mem)
+    {
+        var options = new SimulatorOptions { Address = "01", Seed = 0x12 };
+        return new SimulatorSession(mem, new SimulatorReplyBuilder(options), options,
+            () => new DateTime(2025, 1, 1, 0, 0, 0));
+    }
+
+    [Fact]
+    public void StartSession_RepliesAckAndPasswordSeed()
+    {
+        var session = NewSession(new SimulatorMemory());
+        string start = PacketCodec.BuildData(0, 0, "01", "02");
+
+        var outPackets = session.Handle(start);
+
+        Assert.Contains(outPackets, p => p[0] == ProtocolConstants.ACK);
+        Assert.Contains(outPackets, p =>
+            PacketCodec.TryParse(p, out var d, out var k) && k == 'D' && d.Mi == 0x03 && d.AppData == "0312");
+    }
+
+    [Fact]
+    public void Heartbeat_RepliesStatusReply()
+    {
+        var session = NewSession(new SimulatorMemory());
+        var heartbeat = PacketCodec.BuildData(0, 0, "01", "05");
+
+        var outPackets = session.Handle(heartbeat);
+
+        Assert.Contains(outPackets, p =>
+            PacketCodec.TryParse(p, out var d, out var k) && k == 'D' && d.Mi == 0x06);
+    }
+
+    [Fact]
+    public void SetTextFrame_StoresFrame_AndRepliesStatus()
+    {
+        var mem = new SimulatorMemory();
+        var session = NewSession(mem);
+        string appData = SetCommandParser.BuildTextFrameAppData(
+            new StoredTextFrame(7, 1, 0, 0, 0, 5, "48454C4C4F"));
+        var packet = PacketCodec.BuildData(0, 0, "01", appData);
+
+        var outPackets = session.Handle(packet);
+
+        Assert.NotNull(mem.GetTextFrame(7));
+        Assert.Contains(outPackets, p =>
+            PacketCodec.TryParse(p, out var d, out var k) && k == 'D' && d.Mi == 0x06);
+    }
+
+    [Fact]
+    public void DisplayFrame_MarksFrameActive_AndAcks()
+    {
+        var mem = new SimulatorMemory();
+        mem.PutTextFrame(new StoredTextFrame(7, 3, 0, 0, 0, 5, "48454C4C4F"));
+        var session = NewSession(mem);
+        var packet = PacketCodec.BuildData(0, 0, "01", "0E" + "01" + "07"); // group 1, frame 7
+
+        var outPackets = session.Handle(packet);
+
+        Assert.Equal(7, mem.ActiveFrameId);
+        Assert.Equal(3, mem.ActiveFrameRevision); // picked up from stored frame
+        Assert.Contains(outPackets, p =>
+            PacketCodec.TryParse(p, out var d, out var k) && k == 'D' && d.Mi == 0x01);
+    }
+
+    [Fact]
+    public void RequestStoredFrame_EchoesStoredFrame()
+    {
+        var mem = new SimulatorMemory();
+        mem.PutTextFrame(new StoredTextFrame(7, 1, 0, 0, 0, 5, "48454C4C4F"));
+        var session = NewSession(mem);
+        // RequestType 1 = Frame, id 7
+        var packet = PacketCodec.BuildData(0, 0, "01", "17" + "01" + "07");
+
+        var outPackets = session.Handle(packet);
+
+        Assert.Contains(outPackets, p =>
+            PacketCodec.TryParse(p, out var d, out var k) && k == 'D' && d.Mi == 0x0A);
+    }
+
+    [Fact]
+    public void UnsupportedMi_Rejects()
+    {
+        var session = NewSession(new SimulatorMemory());
+        var packet = PacketCodec.BuildData(0, 0, "01", "40"); // HAR status — out of scope
+
+        var outPackets = session.Handle(packet);
+
+        Assert.Contains(outPackets, p =>
+            PacketCodec.TryParse(p, out var d, out var k) && k == 'D' && d.Mi == 0x00);
+    }
+
+    [Fact]
+    public void BadCrc_EmitsNak_AndDoesNotStoreFrame()
+    {
+        var mem = new SimulatorMemory();
+        var session = NewSession(mem);
+        // Build a valid SetTextFrame packet for frame id 7
+        string appData = SetCommandParser.BuildTextFrameAppData(
+            new StoredTextFrame(7, 1, 0, 0, 0, 5, "48454C4C4F"));
+        string validPacket = PacketCodec.BuildData(0, 0, "01", appData);
+
+        // Corrupt a character in the application-data region (index 9 is inside appdata)
+        // The body is: SOH(1)+NS(2)+NR(2)+ADDR(2)+STX(1) = 8 chars before appdata starts at index 8
+        // Flip a hex digit in the appdata at index 9 (0-based)
+        char[] chars = validPacket.ToCharArray();
+        chars[9] = chars[9] == '0' ? '1' : '0'; // flip one digit
+        string corruptPacket = new string(chars);
+
+        var outPackets = session.Handle(corruptPacket);
+
+        // Should emit a NAK (not an ACK), and should NOT store the frame
+        Assert.Contains(outPackets, p => p[0] == ProtocolConstants.NAK);
+        Assert.DoesNotContain(outPackets, p => p[0] == ProtocolConstants.ACK);
+        Assert.Null(mem.GetTextFrame(7));
+    }
+}

--- a/tests/TSISP003.Tests/Simulator/SimulatorSessionTests.cs
+++ b/tests/TSISP003.Tests/Simulator/SimulatorSessionTests.cs
@@ -323,6 +323,22 @@ public class SimulatorSessionTests
     }
 
     [Fact]
+    public void MalformedPacket_WithValidCrc_RepliesRejectNotThrow()
+    {
+        // DisplayFrame (MI 0E) with group byte but missing the frame-id byte.
+        // PacketCodec.BuildData produces a CRC-valid packet; Dispatch will throw
+        // ArgumentOutOfRangeException when it tries a[4..6]. Handle must catch it
+        // and reply with a Reject (MI 0x00) rather than propagating the exception.
+        var session = NewSession(new SimulatorMemory());
+        var packet = PacketCodec.BuildData(0, 0, "01", "0E01"); // MI 0E + group 01, frame-id missing
+
+        var outPackets = session.Handle(packet);
+
+        Assert.Contains(outPackets, p =>
+            PacketCodec.TryParse(p, out var d, out var k) && k == 'D' && d.Mi == 0x00);
+    }
+
+    [Fact]
     public void SplitPacket_BufferedAndProcessedWhenComplete()
     {
         var session = NewSession(new SimulatorMemory());

--- a/tests/TSISP003.Tests/Simulator/SimulatorSessionTests.cs
+++ b/tests/TSISP003.Tests/Simulator/SimulatorSessionTests.cs
@@ -124,4 +124,219 @@ public class SimulatorSessionTests
         Assert.DoesNotContain(outPackets, p => p[0] == ProtocolConstants.ACK);
         Assert.Null(mem.GetTextFrame(7));
     }
+
+    // ---- Fix 1: state machine ----
+
+    [Fact]
+    public void StateMachine_FreshSession_IsIdle()
+    {
+        var session = NewSession(new SimulatorMemory());
+        Assert.Equal(SimulatorSession.State.Idle, session.CurrentState);
+    }
+
+    [Fact]
+    public void StateMachine_AfterStartAndPassword_IsOnline()
+    {
+        var session = NewSession(new SimulatorMemory());
+        string startPacket = PacketCodec.BuildData(0, 0, "01", "02");
+        session.Handle(startPacket);
+        // After StartSession (MI 02), state should be SeedSent
+        Assert.Equal(SimulatorSession.State.SeedSent, session.CurrentState);
+
+        string passwordPacket = PacketCodec.BuildData(1, 1, "01", "04");
+        session.Handle(passwordPacket);
+        // After Password (MI 04), state should be Online
+        Assert.Equal(SimulatorSession.State.Online, session.CurrentState);
+    }
+
+    // ---- Fix 3: coverage of untested dispatch branches ----
+
+    [Fact]
+    public void ConfigRequest_RepliesConfigReply()
+    {
+        var session = NewSession(new SimulatorMemory());
+        var packet = PacketCodec.BuildData(0, 0, "01", "21");
+
+        var outPackets = session.Handle(packet);
+
+        Assert.Contains(outPackets, p =>
+            PacketCodec.TryParse(p, out var d, out var k) && k == 'D' && d.Mi == 0x22);
+    }
+
+    [Fact]
+    public void SetGraphicsFrame_StoresFrame_AndRepliesStatus()
+    {
+        var mem = new SimulatorMemory();
+        var session = NewSession(mem);
+        string appData = SetCommandParser.BuildGraphicsFrameAppData(
+            new StoredGraphicsFrame(3, 2, 18, 48, 1, 0, 2, "ABCD"));
+        var packet = PacketCodec.BuildData(0, 0, "01", appData);
+
+        var outPackets = session.Handle(packet);
+
+        Assert.NotNull(mem.GetGraphicsFrame(3));
+        Assert.Contains(outPackets, p =>
+            PacketCodec.TryParse(p, out var d, out var k) && k == 'D' && d.Mi == 0x06);
+    }
+
+    [Fact]
+    public void SetMessage_StoresMessage_AndRepliesStatus()
+    {
+        var mem = new SimulatorMemory();
+        var session = NewSession(mem);
+        string appData = SetCommandParser.BuildMessageAppData(
+            new StoredMessage(2, 1, 5, new (byte, byte)[] { (7, 10) }));
+        var packet = PacketCodec.BuildData(0, 0, "01", appData);
+
+        var outPackets = session.Handle(packet);
+
+        Assert.NotNull(mem.GetMessage(2));
+        Assert.Contains(outPackets, p =>
+            PacketCodec.TryParse(p, out var d, out var k) && k == 'D' && d.Mi == 0x06);
+    }
+
+    [Fact]
+    public void SetPlan_StoresPlan_AndRepliesStatus()
+    {
+        var mem = new SimulatorMemory();
+        var session = NewSession(mem);
+        string appData = SetCommandParser.BuildPlanAppData(
+            new StoredPlan(1, 1, 0x7F, new[] { new StoredPlanEntry(1, 7, 8, 0, 17, 30) }));
+        var packet = PacketCodec.BuildData(0, 0, "01", appData);
+
+        var outPackets = session.Handle(packet);
+
+        Assert.NotNull(mem.GetPlan(1));
+        Assert.Contains(outPackets, p =>
+            PacketCodec.TryParse(p, out var d, out var k) && k == 'D' && d.Mi == 0x06);
+    }
+
+    [Fact]
+    public void DisplayMessage_SetsActiveMessage_AndAcks()
+    {
+        var mem = new SimulatorMemory();
+        mem.PutMessage(new StoredMessage(2, 4, 5, new (byte, byte)[] { (1, 3) }));
+        var session = NewSession(mem);
+        // MI=0F, group=01, msgId=02
+        var packet = PacketCodec.BuildData(0, 0, "01", "0F" + "01" + "02");
+
+        var outPackets = session.Handle(packet);
+
+        Assert.Equal(2, mem.ActiveMessageId);
+        Assert.Equal(4, mem.ActiveMessageRevision);
+        Assert.Contains(outPackets, p =>
+            PacketCodec.TryParse(p, out var d, out var k) && k == 'D' && d.Mi == 0x01);
+    }
+
+    [Fact]
+    public void EnablePlan_Then_RequestEnabledPlans_Then_DisablePlan()
+    {
+        var mem = new SimulatorMemory();
+        var session = NewSession(mem);
+
+        // Enable plan: group=01, plan=05
+        var enablePacket = PacketCodec.BuildData(0, 0, "01", "10" + "01" + "05");
+        var enableReply = session.Handle(enablePacket);
+        Assert.Contains(enableReply, p =>
+            PacketCodec.TryParse(p, out var d, out var k) && k == 'D' && d.Mi == 0x01);
+
+        // Request enabled plans → MI 0x13 with one entry "0105"
+        var reqPacket = PacketCodec.BuildData(1, 1, "01", "12");
+        var reqReply = session.Handle(reqPacket);
+        Assert.Contains(reqReply, p =>
+            PacketCodec.TryParse(p, out var d, out var k) && k == 'D' && d.Mi == 0x13
+            && d.AppData.Contains("0105", StringComparison.OrdinalIgnoreCase));
+
+        // Disable plan: group=01, plan=05
+        var disablePacket = PacketCodec.BuildData(2, 2, "01", "11" + "01" + "05");
+        var disableReply = session.Handle(disablePacket);
+        Assert.Contains(disableReply, p =>
+            PacketCodec.TryParse(p, out var d, out var k) && k == 'D' && d.Mi == 0x01);
+
+        // Request enabled plans again → MI 0x13 with count "00"
+        var reqPacket2 = PacketCodec.BuildData(3, 3, "01", "12");
+        var reqReply2 = session.Handle(reqPacket2);
+        Assert.Contains(reqReply2, p =>
+            PacketCodec.TryParse(p, out var d, out var k) && k == 'D' && d.Mi == 0x13
+            && d.AppData[2..4] == "00");
+    }
+
+    [Fact]
+    public void EndSession_AcksAndResetsStateToIdle()
+    {
+        var session = NewSession(new SimulatorMemory());
+        // Drive to Online first
+        session.Handle(PacketCodec.BuildData(0, 0, "01", "02"));
+        session.Handle(PacketCodec.BuildData(1, 1, "01", "04"));
+        Assert.Equal(SimulatorSession.State.Online, session.CurrentState);
+
+        // End session
+        var packet = PacketCodec.BuildData(2, 2, "01", "07");
+        var outPackets = session.Handle(packet);
+
+        Assert.Contains(outPackets, p =>
+            PacketCodec.TryParse(p, out var d, out var k) && k == 'D' && d.Mi == 0x01);
+        Assert.Equal(SimulatorSession.State.Idle, session.CurrentState);
+    }
+
+    [Fact]
+    public void RequestStored_Message_ReturnsMessageAppData()
+    {
+        var mem = new SimulatorMemory();
+        mem.PutMessage(new StoredMessage(2, 3, 5, new (byte, byte)[] { (1, 2) }));
+        var session = NewSession(mem);
+        // RequestType 2 = Message, id 2
+        var packet = PacketCodec.BuildData(0, 0, "01", "17" + "02" + "02");
+
+        var outPackets = session.Handle(packet);
+
+        Assert.Contains(outPackets, p =>
+            PacketCodec.TryParse(p, out var d, out var k) && k == 'D' && d.Mi == 0x0C);
+    }
+
+    [Fact]
+    public void RequestStored_Plan_ReturnsPlanAppData()
+    {
+        var mem = new SimulatorMemory();
+        mem.PutPlan(new StoredPlan(1, 2, 0x7F, new[] { new StoredPlanEntry(1, 7, 8, 0, 17, 30) }));
+        var session = NewSession(mem);
+        // RequestType 3 = Plan, id 1
+        var packet = PacketCodec.BuildData(0, 0, "01", "17" + "03" + "01");
+
+        var outPackets = session.Handle(packet);
+
+        Assert.Contains(outPackets, p =>
+            PacketCodec.TryParse(p, out var d, out var k) && k == 'D' && d.Mi == 0x0D);
+    }
+
+    [Fact]
+    public void RequestStored_NotFound_RejectsWithMiZero()
+    {
+        var session = NewSession(new SimulatorMemory());
+        // RequestType 1 = Frame, id 0x63 — not stored
+        var packet = PacketCodec.BuildData(0, 0, "01", "17" + "01" + "63");
+
+        var outPackets = session.Handle(packet);
+
+        Assert.Contains(outPackets, p =>
+            PacketCodec.TryParse(p, out var d, out var k) && k == 'D' && d.Mi == 0x00);
+    }
+
+    [Fact]
+    public void SplitPacket_BufferedAndProcessedWhenComplete()
+    {
+        var session = NewSession(new SimulatorMemory());
+        // A valid heartbeat packet
+        string p = PacketCodec.BuildData(0, 0, "01", "05");
+
+        // Send first 4 chars — incomplete, no ETX yet
+        var partial = session.Handle(p[..4]);
+        Assert.DoesNotContain(partial, pkt =>
+            PacketCodec.TryParse(pkt, out var d, out var k) && k == 'D');
+
+        // Send the rest — now the buffer has the full packet
+        var full = session.Handle(p[4..]);
+        Assert.Contains(full, pkt =>
+            PacketCodec.TryParse(pkt, out var d, out var k) && k == 'D' && d.Mi == 0x06);
+    }
 }

--- a/tests/TSISP003.Tests/Simulator/SimulatorSessionTests.cs
+++ b/tests/TSISP003.Tests/Simulator/SimulatorSessionTests.cs
@@ -67,10 +67,31 @@ public class SimulatorSessionTests
 
         var outPackets = session.Handle(packet);
 
-        Assert.Equal(7, mem.ActiveFrameId);
-        Assert.Equal(3, mem.ActiveFrameRevision); // picked up from stored frame
+        var sign = mem.SnapshotSigns()[0];
+        Assert.Equal((byte)7, sign.FrameId);
+        Assert.Equal((byte)3, sign.FrameRevision); // picked up from stored frame
         Assert.Contains(outPackets, p =>
             PacketCodec.TryParse(p, out var d, out var k) && k == 'D' && d.Mi == 0x01);
+    }
+
+    [Fact]
+    public void DisplayAtomicFrames_SetsPerSignFrames_AndRepliesStatus()
+    {
+        var mem = new SimulatorMemory(3);
+        mem.PutTextFrame(new StoredTextFrame(7, 1, 0, 0, 0, 5, "48454C4C4F"));
+        mem.PutTextFrame(new StoredTextFrame(9, 2, 0, 0, 0, 5, "48454C4C4F"));
+        var session = NewSession(mem);
+        // MI=2B, group=01, numSigns=02, (sign 01 -> frame 07), (sign 02 -> frame 09)
+        var packet = PacketCodec.BuildData(0, 0, "01", "2B" + "01" + "02" + "0107" + "0209");
+
+        var outPackets = session.Handle(packet);
+
+        var signs = mem.SnapshotSigns();
+        Assert.Equal((byte)7, signs[0].FrameId); // sign 1 -> frame 7
+        Assert.Equal((byte)9, signs[1].FrameId); // sign 2 -> frame 9
+        Assert.Equal((byte)0, signs[2].FrameId); // sign 3 untouched
+        Assert.Contains(outPackets, p =>
+            PacketCodec.TryParse(p, out var d, out var k) && k == 'D' && d.Mi == 0x06);
     }
 
     [Fact]
@@ -222,8 +243,9 @@ public class SimulatorSessionTests
 
         var outPackets = session.Handle(packet);
 
-        Assert.Equal(2, mem.ActiveMessageId);
-        Assert.Equal(4, mem.ActiveMessageRevision);
+        var sign = mem.SnapshotSigns()[0];
+        Assert.Equal((byte)2, sign.MessageId);
+        Assert.Equal((byte)4, sign.MessageRevision);
         Assert.Contains(outPackets, p =>
             PacketCodec.TryParse(p, out var d, out var k) && k == 'D' && d.Mi == 0x01);
     }

--- a/tests/TSISP003.Tests/TSISP003.Tests.csproj
+++ b/tests/TSISP003.Tests/TSISP003.Tests.csproj
@@ -28,6 +28,7 @@
     <ProjectReference Include="..\..\src\TSISP003.Application\TSISP003.Application.csproj" />
     <ProjectReference Include="..\..\src\TSISP003.Infrastructure\TSISP003.Infrastructure.csproj" />
     <ProjectReference Include="..\..\src\TSISP003.Api\TSISP003.Api.csproj" />
+    <ProjectReference Include="..\..\src\TSISP003.Simulator\TSISP003.Simulator.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/TSISP003.Tests/Utilities/ExtensionsTests.cs
+++ b/tests/TSISP003.Tests/Utilities/ExtensionsTests.cs
@@ -96,7 +96,7 @@ public class ExtensionsTests
         var signGroup = new SignGroup
         {
             GroupID = 1,
-            Signs = null
+            Signs = null! // deliberately null to verify AsDto tolerates a missing dictionary
         };
 
         // Act

--- a/tests/TSISP003.Tests/Utilities/FunctionsTests.cs
+++ b/tests/TSISP003.Tests/Utilities/FunctionsTests.cs
@@ -1,4 +1,4 @@
-using TSISP003.Infrastructure.Protocol;
+using TSISP003.Protocol;
 
 namespace TSISP003.Tests.Utilities;
 


### PR DESCRIPTION
## Summary

Adds a full TSI-SP-003 protocol **simulator** plus a set of API/management improvements, all verified end-to-end against the real client.

### Simulator
- New shared `TSISP003.Protocol` library (extracted `ProtocolConstants`/`ProtocolHelper`, added `PacketCodec`) so client and simulator share identical framing/CRC/password code.
- New `TSISP003.Simulator` project: in-memory store, reply builder, set-command parsers, a session state machine (handshake → set/store → display/status → request-stored; CRC→NAK), and a TCP listener host.
- **Multi-controller**: one process hosts N sign controllers (default 3 on ports 5050/5051/5052), each a group of **3 text signs** with per-sign display state.
- Wired into the **Aspire AppHost** (3 TCP endpoints; API configured with 3 devices). Default port 5050 to avoid the macOS AirPlay conflict on 5000.

### API / management
- **Per-controller Debug transaction logging** in `SignControllerService` (e.g. `[SignController sim-1] TX Heartbeat (N(S)=…)`), enabled by default via the API's `appsettings.json`.
- Moved the `/extended/...` endpoints into a dedicated **`ExtendedController`** backed by a new `IExtendedSignService`/`ExtendedSignService`.
- **`GET api/devices`** lists configured devices (name/address/host/port; no secrets).
- **`GET api/{device}/extended/status`** enriched: resolves each sign's active message/frame live via Request-Stored and folds in the decoded frame text/times/colours.

### Quality
- Cleared all build warnings (patched MessagePack/OpenTelemetry vulnerabilities + code warnings).
- **572 tests** green; **0 build warnings**; endpoints and protocol round-trips verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)